### PR TITLE
Wrapped Rfc2898DeriveBytes into using statement

### DIFF
--- a/Kerberos.NET/Crypto/AES/AESEncryptor.cs
+++ b/Kerberos.NET/Crypto/AES/AESEncryptor.cs
@@ -90,9 +90,10 @@ namespace Kerberos.NET.Crypto
 
         private static byte[] PBKDF2(byte[] passwordBytes, byte[] salt, int iterations, int keySize)
         {
-            var derive = new Rfc2898DeriveBytes(passwordBytes, salt, iterations);
-
-            return derive.GetBytes(keySize);
+            using (var derive = new Rfc2898DeriveBytes(passwordBytes, salt, iterations))
+            {
+                return derive.GetBytes(keySize);
+            }
         }
 
         protected static int GetIterations(byte[] param, int defCount)


### PR DESCRIPTION
Object of Rfc2898DeriveBytes class should call Dispose at the end of using.
I suggest to wrap it into using statement.