### PR TITLE
Added casting uint value to long in order to make 32 bit shifting correct

### DIFF
--- a/Kerberos.NET/Entities/Authorization/NdrBinaryReader.cs
+++ b/Kerberos.NET/Entities/Authorization/NdrBinaryReader.cs
@@ -96,7 +96,7 @@ namespace Kerberos.NET.Entities.Authorization
 
             if (low != 0xffffffffL && high != 0x7fffffffL)
             {
-                var fileTime = (high << 32) + low;
+                var fileTime = ((long)high << 32) + low;
 
                 var universalTicks = fileTime + FileTimeOffset;
 

--- a/Tests/Tests.Kerberos.NET/ValidatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/ValidatorTests.cs
@@ -2,8 +2,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
+using Kerberos.NET.Entities;
+using Kerberos.NET.Entities.Authorization;
 
 namespace Tests.Kerberos.NET
 {
@@ -128,6 +131,68 @@ namespace Tests.Kerberos.NET
             added = await replay.Add(entry);
 
             Assert.IsTrue(added);
+        }
+
+        [TestMethod]
+        public async Task TestValidatorCheckPacLogonInfo()
+        {
+            var data = ReadFile("rc4-kerberos-data");
+            var key = ReadFile("rc4-key-data");
+
+            var validator = new KerberosValidator(key) { ValidateAfterDecrypt = ValidationActions.Replay };
+            var result = await validator.Validate(data);
+            var pac = (PacElement)result.Ticket.AuthorizationData
+                .Select(d => d.Authorizations.First(a => a.Type == AuthorizationDataValueType.AD_WIN2K_PAC))
+                .First();
+
+            var expectedLogonTime = DateTimeOffset.Parse("1/9/2009 5:15:20 PM +00:00", CultureInfo.InvariantCulture);
+            var logonInfo = pac.Certificate.LogonInfo;
+            Assert.AreEqual(expectedLogonTime, Truncate(logonInfo.LogonTime));
+            var expectedLogoffTime = DateTimeOffset.Parse("1/1/0001 12:00:00 AM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedLogoffTime, logonInfo.LogoffTime);
+            var expectedKickOffTime = DateTimeOffset.Parse("1/1/0001 12:00:00 AM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedKickOffTime, logonInfo.KickOffTime);
+            var expectedPwdLastChangeTime = DateTimeOffset.Parse("1/7/2009 2:33:58 PM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedPwdLastChangeTime, Truncate(logonInfo.PwdLastChangeTime));
+            var expectedPwdCanChangeTime = DateTimeOffset.Parse("1/8/2009 2:33:58 PM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedPwdCanChangeTime, Truncate(logonInfo.PwdCanChangeTime));
+            var expectedPwdMustChangeTime = DateTimeOffset.Parse("1/1/0001 12:00:00 AM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedPwdMustChangeTime, logonInfo.PwdMustChangeTime);
+            Assert.AreEqual(46, logonInfo.LogonCount);
+            Assert.AreEqual(0, logonInfo.BadPasswordCount);
+            Assert.AreEqual(UserFlags.LOGON_EXTRA_SIDS, logonInfo.UserFlags);
+            Assert.AreEqual(UserAccountControlFlags.ADS_UF_LOCKOUT | UserAccountControlFlags.ADS_UF_NORMAL_ACCOUNT,
+                logonInfo.UserAccountControl);
+            Assert.AreEqual(0, logonInfo.SubAuthStatus);
+            var expectedLastSuccessfulILogon = DateTimeOffset.Parse("1/1/1601 12:00:00 AM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedLastSuccessfulILogon, logonInfo.LastSuccessfulILogon);
+            var expectedLastLastFailedILogon = DateTimeOffset.Parse("1/1/1601 12:00:00 AM +00:00", CultureInfo.InvariantCulture);
+            Assert.AreEqual(expectedLastLastFailedILogon, logonInfo.LastFailedILogon);
+            Assert.AreEqual("user.test", logonInfo.UserName);
+            Assert.AreEqual("User Test", logonInfo.UserDisplayName);
+            Assert.AreEqual("", logonInfo.LogonScript);
+            Assert.AreEqual("", logonInfo.ProfilePath);
+            Assert.AreEqual("", logonInfo.HomeDirectory);
+            Assert.AreEqual("", logonInfo.HomeDrive);
+            Assert.AreEqual("WS2008", logonInfo.ServerName);
+            Assert.AreEqual("DOMAIN", logonInfo.DomainName);
+            Assert.AreEqual("S-1-5-21-4028881986-3284141023-698984075", logonInfo.DomainSid.Value);
+            Assert.AreEqual("S-1-5-21-4028881986-3284141023-698984075-1106", logonInfo.UserSid.Value);
+            Assert.AreEqual("S-1-5-21-4028881986-3284141023-698984075-513", logonInfo.GroupSid.Value);
+            Assert.AreEqual(11, logonInfo.GroupSids.Count());
+            Assert.AreEqual(7, logonInfo.ExtraSids.Count());
+            Assert.IsNull(logonInfo.ResourceDomainSid);
+            Assert.IsNull(logonInfo.ResourceGroups);
+        }
+
+        private DateTimeOffset Truncate(DateTimeOffset dateTime)
+        {
+            if (dateTime == DateTimeOffset.MinValue || dateTime == DateTimeOffset.MaxValue)
+            {
+                return dateTime;
+            }
+
+            return dateTime.AddTicks(-(dateTime.Ticks % TimeSpan.FromSeconds(1).Ticks));
         }
     }
 }


### PR DESCRIPTION
Shifting by 32 bits for uint32 value is equivalent to shifting by 0 bits. Need to cast it to ulong or long type in order to make shifting  correct.