### PR TITLE
Removed excess part of condition

### DIFF
--- a/Kerberos.NET/Crypto/Asn1Element.cs
+++ b/Kerberos.NET/Crypto/Asn1Element.cs
@@ -78,7 +78,7 @@ namespace Kerberos.NET.Crypto
                 {
                     int childLength = 0;
 
-                    if (children != null && children.Count > 0)
+                    if (children.Count > 0)
                     {
                         foreach (var child in children)
                         {


### PR DESCRIPTION
children object is always not null, no need to check it. I suggest to delete the check.