### PR TITLE
Unify all the validation checks

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -2,7 +2,6 @@
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 using Kerberos.NET.Transport;
-using System;
 using System.Threading.Tasks;
 
 namespace Kerberos.NET.Client
@@ -22,8 +21,9 @@ namespace Kerberos.NET.Client
         //                   -> cache TGT/cache service ticket?
 
         public KerberosClient(string kdc = null)
-            : this(/*new UdpKerberosTransport(kdc),*/ new TcpKerberosTransport(kdc))
+            : this(new TcpKerberosTransport(kdc))
         {
+            // add UdpKerberosTransport for UDP support
         }
 
         private const AuthenticationOptions DefaultAuthentication =

--- a/Kerberos.NET/Entities/Krb/IKerberosMessage.cs
+++ b/Kerberos.NET/Entities/Krb/IKerberosMessage.cs
@@ -1,0 +1,12 @@
+﻿
+namespace Kerberos.NET.Entities
+{
+    public interface IKerberosMessage
+    {
+        MessageType KerberosMessageType { get; }
+
+        string Realm { get; }
+
+        int KerberosProtocolVersionNumber { get; }
+    }
+}

--- a/Kerberos.NET/Entities/Krb/KrbAsRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsRep.cs
@@ -34,13 +34,23 @@ namespace Kerberos.NET.Entities
             var servicePrincipal = await realmService.Principals.RetrieveKrbtgt();
             var servicePrincipalKey = await servicePrincipal.RetrieveLongTermCredential();
 
+            var now = realmService.Now();
+
             KrbAsRep asRep = await GenerateServiceTicket<KrbAsRep>(
-                principal,
-                longTermKey,
-                servicePrincipal,
-                servicePrincipalKey,
-                realmService,
-                addresses: asReq.Addresses
+                new ServiceTicketRequest
+                {
+                    Principal = principal,
+                    EncryptedPartKey = longTermKey,
+                    ServicePrincipal = servicePrincipal,
+                    ServicePrincipalKey = servicePrincipalKey,
+                    Now = now,
+                    Addresses = asReq.Addresses,
+                    RenewTill = now + realmService.Settings.MaximumRenewalWindow,
+                    StartTime = now - realmService.Settings.MaximumSkew,
+                    EndTime = now + realmService.Settings.SessionLifetime,
+                    Flags = DefaultFlags,
+                    RealmName = realmService.Name
+                }
             );
 
             asRep.PaData = requirements.ToArray();

--- a/Kerberos.NET/Entities/Krb/KrbAsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsReq.cs
@@ -9,12 +9,18 @@ using System.Text;
 
 namespace Kerberos.NET.Entities
 {
-    public partial class KrbAsReq
+    public partial class KrbAsReq : IKerberosMessage
     {
         public KrbAsReq()
         {
             MessageType = MessageType.KRB_AS_REQ;
         }
+
+        public MessageType KerberosMessageType => MessageType;
+
+        public string Realm => Body.Realm;
+
+        public int KerberosProtocolVersionNumber => ProtocolVersionNumber;
 
         public static KrbAsReq CreateAsReq(KerberosCredential credential, AuthenticationOptions options)
         {

--- a/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
@@ -6,12 +6,18 @@ using System.Linq;
 
 namespace Kerberos.NET.Entities
 {
-    public partial class KrbTgsReq : IAsn1ApplicationEncoder<KrbTgsReq>
+    public partial class KrbTgsReq : IAsn1ApplicationEncoder<KrbTgsReq>, IKerberosMessage
     {
         public KrbTgsReq()
         {
             MessageType = MessageType.KRB_TGS_REQ;
         }
+
+        public MessageType KerberosMessageType => MessageType;
+
+        public string Realm => Body.Realm;
+
+        public int KerberosProtocolVersionNumber => ProtocolVersionNumber;
 
         public KrbTgsReq DecodeAsApplication(ReadOnlyMemory<byte> encoded)
         {

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -1,0 +1,32 @@
+﻿using Kerberos.NET.Crypto;
+using Kerberos.NET.Server;
+using System;
+using System.Collections.Generic;
+
+namespace Kerberos.NET.Entities
+{
+    public class ServiceTicketRequest
+    {
+        public IKerberosPrincipal Principal { get; set; }
+
+        public KerberosKey EncryptedPartKey { get; set; }
+
+        public IKerberosPrincipal ServicePrincipal { get; set; }
+
+        public KerberosKey ServicePrincipalKey { get; set; }
+
+        public TicketFlags Flags { get; set; }
+
+        public IEnumerable<KrbHostAddress> Addresses { get; set; }
+
+        public string RealmName { get; set; }
+
+        public DateTimeOffset Now { get; set; }
+
+        public DateTimeOffset StartTime { get; set; }
+
+        public DateTimeOffset EndTime { get; set; }
+
+        public DateTimeOffset? RenewTill { get; set; }
+    }
+}

--- a/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
+++ b/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
@@ -7,15 +7,12 @@ using Kerberos.NET.Entities.Pac;
 using Kerberos.NET.Server;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.Kerberos.NET


### PR DESCRIPTION
Keep it simple. Unify all the validation so all messages must look the same.
Pass a ticket request object instead of all the parameters.