### PR TITLE
Fix parsing of KDC override in KerberosTransportBase

### DIFF
--- a/Kerberos.NET/Client/Transport/KerberosTransportBase.cs
+++ b/Kerberos.NET/Client/Transport/KerberosTransportBase.cs
@@ -79,9 +79,13 @@ namespace Kerberos.NET.Transport
                     Target = split[0]
                 };
 
-                if (split.Length > 0)
+                if (split.Length > 1)
                 {
                     record.Port = int.Parse(split[1]);
+                }
+                else
+                {
+                    record.Port = DefaultKerberosPort;
                 }
 
                 return record;


### PR DESCRIPTION
This change fixes a small issue when parsing the override string
given to KerberosClient for KDC name. The condition checking the
array length was incorrect (checking against 0 instead of 1). This
caused array IndexOutOfBoundException when user set the KDC string
without specifying a port number.

Additionally, the default port being used was 0 instead of 88 in
the case of KDC override. Added an else block to set the default.