### PR TITLE
Fixing an issue where TCP stream requires multiple reads

### DIFF
--- a/Kerberos.NET/Client/KerberosClientCacheEntry.cs
+++ b/Kerberos.NET/Client/KerberosClientCacheEntry.cs
@@ -1,0 +1,11 @@
+﻿using Kerberos.NET.Entities;
+
+namespace Kerberos.NET.Client
+{
+    public struct KerberosClientCacheEntry
+    {
+        public KrbEncryptionKey SessionKey;
+
+        public KrbKdcRep Ticket;
+    }
+}

--- a/Kerberos.NET/Client/Transport/IKerberosTransport.cs
+++ b/Kerberos.NET/Client/Transport/IKerberosTransport.cs
@@ -1,6 +1,7 @@
 ﻿using Kerberos.NET.Asn1;
 using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Kerberos.NET.Transport
@@ -15,10 +16,16 @@ namespace Kerberos.NET.Transport
 
         bool Enabled { get; set; }
 
-        Task<TResponse> SendMessage<TRequest, TResponse>(string domain, IAsn1ApplicationEncoder<TRequest> req)
-            where TResponse : IAsn1ApplicationEncoder<TResponse>, new();
+        Task<TResponse> SendMessage<TRequest, TResponse>(
+            string domain, 
+            IAsn1ApplicationEncoder<TRequest> req, 
+            CancellationToken cancellation = default
+        ) where TResponse : IAsn1ApplicationEncoder<TResponse>, new();
 
-        Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> req)
-            where T : IAsn1ApplicationEncoder<T>, new();
+        Task<T> SendMessage<T>(
+            string domain, 
+            ReadOnlyMemory<byte> req, 
+            CancellationToken cancellation = default
+        ) where T : IAsn1ApplicationEncoder<T>, new();
     }
 }

--- a/Kerberos.NET/Client/Transport/KerberosTransportBase.cs
+++ b/Kerberos.NET/Client/Transport/KerberosTransportBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Kerberos.NET.Transport
@@ -59,14 +60,20 @@ namespace Kerberos.NET.Transport
             return new T().DecodeAsApplication(response);
         }
 
-        public virtual Task<TResponse> SendMessage<TRequest, TResponse>(string domain, IAsn1ApplicationEncoder<TRequest> req)
-            where TResponse : IAsn1ApplicationEncoder<TResponse>, new()
+        public virtual Task<TResponse> SendMessage<TRequest, TResponse>(
+            string domain,
+            IAsn1ApplicationEncoder<TRequest> req,
+            CancellationToken cancellation = default
+        ) where TResponse : IAsn1ApplicationEncoder<TResponse>, new()
         {
             return SendMessage<TResponse>(domain, req.EncodeApplication());
         }
 
-        public abstract Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> req)
-            where T : IAsn1ApplicationEncoder<T>, new();
+        public abstract Task<T> SendMessage<T>(
+            string domain,
+            ReadOnlyMemory<byte> req,
+            CancellationToken cancellation = default
+        ) where T : IAsn1ApplicationEncoder<T>, new();
 
         protected DnsRecord QueryDomain(string lookup)
         {

--- a/Kerberos.NET/Client/Transport/KerberosTransportSelector.cs
+++ b/Kerberos.NET/Client/Transport/KerberosTransportSelector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Kerberos.NET.Transport
@@ -21,7 +22,11 @@ namespace Kerberos.NET.Transport
 
         public IEnumerable<IKerberosTransport> Transports => transports;
 
-        public override async Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> encoded)
+        public override async Task<T> SendMessage<T>(
+            string domain, 
+            ReadOnlyMemory<byte> encoded, 
+            CancellationToken cancellation = default
+        )
         {
             // basic logic should be 
             // foreach transport 
@@ -33,7 +38,7 @@ namespace Kerberos.NET.Transport
             {
                 try
                 {
-                    return await transport.SendMessage<T>(domain, encoded);
+                    return await transport.SendMessage<T>(domain, encoded, cancellation);
                 }
                 catch (KerberosTransportException tex)
                 {

--- a/Kerberos.NET/Client/Transport/UdpKerberosTransport.cs
+++ b/Kerberos.NET/Client/Transport/UdpKerberosTransport.cs
@@ -1,6 +1,7 @@
 ﻿using Kerberos.NET.Dns;
 using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Kerberos.NET.Transport
@@ -21,7 +22,11 @@ namespace Kerberos.NET.Transport
             Enabled = false;
         }
 
-        public override async Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> encoded)
+        public override async Task<T> SendMessage<T>(
+            string domain, 
+            ReadOnlyMemory<byte> encoded, 
+            CancellationToken cancellation = default
+        )
         {
             var target = LocateKdc(domain);
 
@@ -29,7 +34,11 @@ namespace Kerberos.NET.Transport
             {
                 Log($"UDP connecting to {target.Target}");
 
+                cancellation.ThrowIfCancellationRequested();
+
                 var result = await client.SendAsync(encoded.ToArray(), encoded.Length);
+
+                cancellation.ThrowIfCancellationRequested();
 
                 var response = await client.ReceiveAsync();
 

--- a/Kerberos.NET/Replay/ITicketCache.cs
+++ b/Kerberos.NET/Replay/ITicketCache.cs
@@ -9,5 +9,7 @@ namespace Kerberos.NET
         Task<bool> Contains(TicketCacheEntry entry);
 
         Task<object> Get(string v);
+
+        Task<T> Get<T>(string v);
     }
 }

--- a/Kerberos.NET/Replay/ITicketReplayValidator.cs
+++ b/Kerberos.NET/Replay/ITicketReplayValidator.cs
@@ -12,7 +12,12 @@ namespace Kerberos.NET
 
     public class TicketCacheEntry
     {
-        public string Computed { get { return $"kerberos-{Container}-{Key}"; } }
+        public string Computed { get { return GenerateKey(Container, Key); } }
+
+        internal static string GenerateKey(string container = null, string key = null)
+        {
+            return $"kerberos-{container}-{key}";
+        }
 
         public string Key { get; set; }
 

--- a/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
+++ b/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
@@ -46,6 +46,30 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public async Task TestE2EWithCaching()
+        {
+            var port = new Random().Next(20000, 40000);
+
+            var options = new ListenerOptions
+            {
+                ListeningOn = new IPEndPoint(IPAddress.Loopback, port),
+                DefaultRealm = "corp2.identityintervention.com".ToUpper(),
+                IsDebug = true,
+                RealmLocator = realm => LocateRealm(realm),
+                ReceiveTimeout = TimeSpan.FromHours(1)
+            };
+
+            using (KdcServiceListener listener = new KdcServiceListener(options))
+            {
+                _ = listener.Start();
+
+                await RequestAndValidateTickets("administrator@corp.identityintervention.com", "P@ssw0rd!", $"127.0.0.1:{port}", caching: true);
+
+                listener.Stop();
+            }
+        }
+
+        [TestMethod]
         public async Task TestE2EWithNegotiate()
         {
             var port = new Random().Next(20000, 40000);
@@ -120,7 +144,10 @@ namespace Tests.Kerberos.NET
             var server = new KerberosClient($"127.0.0.1:{port}");
 
             await server.Authenticate(kerbClientCred);
-            var serverTgt = server.TicketGrantingTicket.Ticket;
+
+            var serverEntry = await server.Cache.Get<KerberosClientCacheEntry>($"krbtgt/{server.DefaultDomain}");
+
+            var serverTgt = serverEntry.Ticket.Ticket;
 
             var apReq = await client.GetServiceTicket("host/u2u", ApOptions.MutualRequired | ApOptions.UseSessionKey, serverTgt);
 
@@ -130,7 +157,7 @@ namespace Tests.Kerberos.NET
 
             Assert.IsNull(decrypted.Ticket);
 
-            decrypted.Decrypt(server.TgtSessionKey.AsKey());
+            decrypted.Decrypt(serverEntry.SessionKey.AsKey());
 
             decrypted.Validate(ValidationActions.All);
 
@@ -199,40 +226,68 @@ namespace Tests.Kerberos.NET
             {
                 _ = listener.Start();
 
+                var exceptions = new List<Exception>();
+
                 var kerbCred = new KerberosPasswordCredential("administrator@corp.identityintervention.com", "P@ssw0rd!");
 
-                KerberosClient client = new KerberosClient($"127.0.0.1:{port}");
+                string kdc = $"127.0.0.1:{port}"; 
+                //string kdc = "10.0.0.21:88";
 
-                await client.Authenticate(kerbCred);
-
-                Task.WaitAll(Enumerable.Range(0, 2).Select(taskNum => Task.Run(async () =>
+                using (KerberosClient client = new KerberosClient(kdc))
                 {
-                    for (var i = 0; i < 10; i++)
+                    client.CacheServiceTickets = false;
+
+                    await client.Authenticate(kerbCred);
+
+                    Task.WaitAll(Enumerable.Range(0, 10).Select(taskNum => Task.Run(async () =>
                     {
-                        if (i % 2 == 0)
+                        for (var i = 0; i < 1000; i++)
                         {
-                            await client.Authenticate(kerbCred);
+                            try
+                            {
+                                if (i % 2 == 0)
+                                {
+                                    await client.Authenticate(kerbCred);
+                                }
+
+                                var ticket = await client.GetServiceTicket(
+                                    "host/appservice.corp.identityintervention.com",
+                                    ApOptions.MutualRequired
+                                );
+
+                                Assert.IsNotNull(ticket.Ticket);
+
+                                await ValidateTicket(ticket);
+                            }
+                            catch (Exception ex)
+                            {
+                                exceptions.Add(ex);
+                            }
                         }
+                    })).ToArray());
+                }
 
-                        var ticket = await client.GetServiceTicket(
-                            "host/appservice.corp.identityintervention.com",
-                            ApOptions.MutualRequired
-                        );
-
-                        await ValidateTicket(ticket);
-                    }
-                })).ToArray());
-
-                client.Dispose();
                 listener.Stop();
+
+                if (exceptions.Count > 0)
+                {
+                    throw new AggregateException($"Failed {exceptions.Count}", exceptions.GroupBy(e => e.GetType()).Select(e => e.First()));
+                }
             }
         }
 
-        private static async Task RequestAndValidateTickets(string user, string password, string overrideKdc, string s4u = null, bool encodeNego = false)
+        private static async Task RequestAndValidateTickets(
+            string user, 
+            string password, 
+            string overrideKdc, 
+            string s4u = null, 
+            bool encodeNego = false, 
+            bool caching = false
+        )
         {
             var kerbCred = new KerberosPasswordCredential(user, password);
 
-            using (KerberosClient client = new KerberosClient(overrideKdc))
+            using (KerberosClient client = new KerberosClient(overrideKdc) { CacheServiceTickets = caching })
             {
                 await client.Authenticate(kerbCred);
 

--- a/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
+++ b/Tests/Tests.Kerberos.NET/E2EKdcClientTest.cs
@@ -239,9 +239,9 @@ namespace Tests.Kerberos.NET
 
                     await client.Authenticate(kerbCred);
 
-                    Task.WaitAll(Enumerable.Range(0, 10).Select(taskNum => Task.Run(async () =>
+                    Task.WaitAll(Enumerable.Range(0, 2).Select(taskNum => Task.Run(async () =>
                     {
-                        for (var i = 0; i < 1000; i++)
+                        for (var i = 0; i < 100; i++)
                         {
                             try
                             {

--- a/Tests/Tests.Kerberos.NET/TransportTests.cs
+++ b/Tests/Tests.Kerberos.NET/TransportTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.Kerberos.NET
@@ -31,7 +32,7 @@ namespace Tests.Kerberos.NET
 
             public override ProtocolType Protocol => ProtocolType.Unspecified;
 
-            public override Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> req)
+            public override Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> req, CancellationToken cancellation = default)
             {
                 var cached = QueryDomain(domain);
 


### PR DESCRIPTION
Under load an AD KDC will buffer responses in the socket and that wasn't handled in the client since it naively expected everything to be in a single response.
Added a smarter caching mechanism to reduce any further impacts on request failures