### PR TITLE
Smarter about honoring PAC request

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,3 +39,8 @@ end_of_line = lf
 
 [*.{cmd,bat}]
 end_of_line = crlf
+
+[*.cs]
+
+# IDE0063: Use simple 'using' statement
+csharp_prefer_simple_using_statement = true:silent

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -164,7 +164,6 @@ namespace Kerberos.NET.Client
                     CTime = authenticator.CTime,
                     CuSec = authenticator.CuSec,
                     SequenceNumber = authenticator.SequenceNumber
-
                 };
             }
         }
@@ -193,8 +192,8 @@ namespace Kerberos.NET.Client
         }
 
         private async Task<KerberosClientCacheEntry> RequestTgs(
-            RequestServiceTicket rst, 
-            KerberosClientCacheEntry tgtEntry, 
+            RequestServiceTicket rst,
+            KerberosClientCacheEntry tgtEntry,
             CancellationToken cancellation
         )
         {

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Kerberos.NET.Entities;
+﻿using Kerberos.NET.Entities;
+using System;
 
 namespace Kerberos.NET.Crypto
 {

--- a/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
@@ -1,5 +1,4 @@
 ﻿using Kerberos.NET.Entities;
-using System;
 
 namespace Kerberos.NET.Crypto
 {

--- a/Kerberos.NET/Entities/KerberosConstants.cs
+++ b/Kerberos.NET/Entities/KerberosConstants.cs
@@ -68,6 +68,14 @@ namespace Kerberos.NET.Entities
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Now(out DateTimeOffset time, out int? usec)
+        {
+            Now(out time, out int usecExplicit);
+
+            usec = usecExplicit;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<byte> UnicodeBytesToUtf8(byte[] str)
         {
             return Encoding.Convert(Encoding.Unicode, Encoding.UTF8, str, 0, str.Length);

--- a/Kerberos.NET/Entities/Krb/KrbApReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApReq.cs
@@ -21,9 +21,11 @@ namespace Kerberos.NET.Entities
         }
 
         internal static KrbApReq CreateApReq(
-            KrbKdcRep tgsRep, 
-            KerberosKey authenticatorKey, 
-            ApOptions options, out KrbAuthenticator authenticator)
+            KrbKdcRep tgsRep,
+            KerberosKey authenticatorKey,
+            ApOptions options,
+            out KrbAuthenticator authenticator
+        )
         {
             var ticket = tgsRep.Ticket;
 

--- a/Kerberos.NET/Entities/Krb/KrbAsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsReq.cs
@@ -27,26 +27,23 @@ namespace Kerberos.NET.Entities
 
             var hostAddress = Environment.MachineName;
 
-            var padata = new List<KrbPaData>() {
+            var pacRequest = new KrbPaPacRequest
+            {
+                IncludePac = options.HasFlag(AuthenticationOptions.IncludePacRequest)
+            };
+
+            var padata = new List<KrbPaData>()
+            {
                 new KrbPaData
                 {
                     Type = PaDataType.PA_PAC_REQUEST,
-                    Value = new KrbPaPacRequest
-                    {
-                        IncludePac = options.HasFlag(AuthenticationOptions.IncludePacRequest)
-                    }.Encode().AsMemory()
+                    Value = pacRequest.Encode().AsMemory()
                 }
             };
 
             if (options.HasFlag(AuthenticationOptions.PreAuthenticate))
             {
-                KerberosConstants.Now(out DateTimeOffset timestamp, out int usec);
-
-                var ts = new KrbPaEncTsEnc
-                {
-                    PaTimestamp = timestamp,
-                    PaUSec = usec
-                };
+                var ts = KrbPaEncTsEnc.Now();
 
                 var tsEncoded = ts.Encode().AsMemory();
 

--- a/Kerberos.NET/Entities/Krb/KrbPaEncTsEnc.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaEncTsEnc.cs
@@ -1,0 +1,14 @@
+﻿namespace Kerberos.NET.Entities
+{
+    public partial class KrbPaEncTsEnc
+    {
+        internal static KrbPaEncTsEnc Now()
+        {
+            var ts = new KrbPaEncTsEnc();
+
+            KerberosConstants.Now(out ts.PaTimestamp, out ts.PaUSec);
+
+            return ts;
+        }
+    }
+}

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Kerberos.NET.Entities
 {
-    public class ServiceTicketRequest
+    public struct ServiceTicketRequest
     {
         public IKerberosPrincipal Principal { get; set; }
 
@@ -28,7 +28,9 @@ namespace Kerberos.NET.Entities
         public DateTimeOffset EndTime { get; set; }
 
         public DateTimeOffset? RenewTill { get; set; }
-        
+
         public int Nonce { get; set; }
+
+        public bool IncludePac { get; set; }
     }
 }

--- a/Kerberos.NET/Server/KdcMessageHandlerBase.cs
+++ b/Kerberos.NET/Server/KdcMessageHandlerBase.cs
@@ -1,5 +1,4 @@
 ﻿using Kerberos.NET.Entities;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -90,7 +90,8 @@ namespace Kerberos.NET.Server
                     StartTime = now - RealmService.Settings.MaximumSkew,
                     EndTime = now + RealmService.Settings.SessionLifetime,
                     Flags = KrbKdcRep.DefaultFlags,
-                    Now = now
+                    Now = now,
+                    IncludePac = krbtgtApReqDecrypted.Ticket.AuthorizationData.Any(a => a.Type == AuthorizationDataType.AdIfRelevant)
                 }
             );
 


### PR DESCRIPTION
PAC inclusion should be decided by the PA-Data request as defined by [MS-PAC] and [MS-KILE].

Improved the API for creating arbitrary tickets to pass only the required data instead of larger messages.

Expanded E2E tests to run through all the scenarios explicitly.