### PR TITLE
Flipped AsMemory usage for fewer allocations and copying

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,3 +44,12 @@ end_of_line = crlf
 
 # IDE0063: Use simple 'using' statement
 csharp_prefer_simple_using_statement = true:silent
+
+# IDE0008: Use explicit type
+csharp_style_var_elsewhere = false:none
+
+# IDE0008: Use explicit type
+csharp_style_var_when_type_is_apparent = false:none
+
+# IDE0008: Use explicit type
+csharp_style_var_for_built_in_types = false:none

--- a/KerbDump/Form1.cs
+++ b/KerbDump/Form1.cs
@@ -287,12 +287,12 @@ namespace KerbDump
 
             var keys = keytab.Entries.Select(k =>
             {
+                var keyBytes = k.Key.GetKey(
+                    CryptoService.CreateTransform(EncryptionType.NULL)
+                );
+
                 var key = new KerberosKey(
-                    Encoding.Unicode.GetString(
-                        k.Key.GetKey(
-                            CryptoService.CreateTransform(EncryptionType.NULL)
-                        )
-                    ),
+                    Encoding.Unicode.GetString(keyBytes.ToArray()),
                     k.Principal
                 );
 

--- a/KerbDump/NoopTransform.cs
+++ b/KerbDump/NoopTransform.cs
@@ -16,12 +16,12 @@ namespace KerbDump
             return data;
         }
 
-        public override ReadOnlySpan<byte> Decrypt(ReadOnlyMemory<byte> cipher, KerberosKey key, KeyUsage usage)
+        public override ReadOnlyMemory<byte> Decrypt(ReadOnlyMemory<byte> cipher, KerberosKey key, KeyUsage usage)
         {
             return cipher.ToArray();
         }
 
-        public override ReadOnlySpan<byte> String2Key(KerberosKey key)
+        public override ReadOnlyMemory<byte> String2Key(KerberosKey key)
         {
             return key.PasswordBytes;
         }

--- a/Kerberos.NET/Asn1/Experimental/AsnWriter.cs
+++ b/Kerberos.NET/Asn1/Experimental/AsnWriter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -176,6 +176,11 @@ namespace System.Security.Cryptography.Asn1
 
         internal ReadOnlySpan<byte> EncodeAsSpan()
         {
+            return EncodeAsMemory().Span;
+        }
+
+        internal ReadOnlyMemory<byte> EncodeAsMemory()
+        {
             CheckDisposed();
 
             if ((_nestingStack?.Count ?? 0) != 0)
@@ -185,12 +190,17 @@ namespace System.Security.Cryptography.Asn1
 
             if (_offset == 0)
             {
-                return ReadOnlySpan<byte>.Empty;
+                return ReadOnlyMemory<byte>.Empty;
             }
 
             // If the stack is closed out then everything is a definite encoding (BER, DER) or a
             // required indefinite encoding (CER). So we're correctly sized up, and ready to copy.
-            return new ReadOnlySpan<byte>(_buffer, 0, _offset);
+
+            var memory = new Memory<byte>(new byte[_buffer.Length]);
+
+            _buffer.CopyTo(memory);
+
+            return memory.Slice(0, _offset);
         }
 
         /// <summary>

--- a/Kerberos.NET/Asn1/asn.xslt
+++ b/Kerberos.NET/Asn1/asn.xslt
@@ -106,13 +106,13 @@ namespace <xsl:value-of select="@namespace" />
         }
 #endif
  </xsl:if>
-        public ReadOnlySpan&lt;byte&gt; Encode()
+        public ReadOnlyMemory&lt;byte&gt; Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -184,9 +184,7 @@ namespace <xsl:value-of select="@namespace" />
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         
@@ -283,13 +281,13 @@ namespace <xsl:value-of select="@namespace" />
             <xsl:apply-templates mode="EnsureUniqueTag" />
         }
 #endif
-        public ReadOnlySpan&lt;byte&gt; Encode()
+        public ReadOnlyMemory&lt;byte&gt; Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -334,9 +332,7 @@ namespace <xsl:value-of select="@namespace" />
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -252,8 +252,8 @@ namespace Kerberos.NET.Client
                     throw new InvalidOperationException("Cannot request a service ticket until a user is authenticated");
                 }
 
-                entry.SessionKey = KrbEncryptionKey.Decode(entry.SessionKey.Encode().AsMemory());
-                entry.Ticket = KrbKdcRep.Decode(entry.Ticket.Encode().AsMemory());
+                entry.SessionKey = KrbEncryptionKey.Decode(entry.SessionKey.Encode());
+                entry.Ticket = KrbKdcRep.Decode(entry.Ticket.Encode());
             }
 
             return entry;

--- a/Kerberos.NET/Crypto/KerberosChecksum.cs
+++ b/Kerberos.NET/Crypto/KerberosChecksum.cs
@@ -27,10 +27,10 @@ namespace Kerberos.NET.Crypto
 
         public void Sign(KerberosKey key)
         {
-            Signature = SignInternal(key).AsMemory();
+            Signature = SignInternal(key);
         }
 
-        protected abstract ReadOnlySpan<byte> SignInternal(KerberosKey key);
+        protected abstract ReadOnlyMemory<byte> SignInternal(KerberosKey key);
 
         protected abstract bool ValidateInternal(KerberosKey key);
     }
@@ -61,10 +61,10 @@ namespace Kerberos.NET.Crypto
             this.decryptor = decryptor;
         }
 
-        protected override ReadOnlySpan<byte> SignInternal(KerberosKey key)
+        protected override ReadOnlyMemory<byte> SignInternal(KerberosKey key)
         {
             return decryptor.MakeChecksum(
-                Data.Span,
+                Data,
                 key,
                 Usage,
                 KeyDerivationMode.Kc,
@@ -76,7 +76,7 @@ namespace Kerberos.NET.Crypto
         {
             var actualChecksum = SignInternal(key);
 
-            return KerberosCryptoTransformer.AreEqualSlow(actualChecksum, Signature.Span);
+            return KerberosCryptoTransformer.AreEqualSlow(actualChecksum.Span, Signature.Span);
         }
     }
 
@@ -87,7 +87,7 @@ namespace Kerberos.NET.Crypto
         {
         }
 
-        protected override ReadOnlySpan<byte> SignInternal(KerberosKey key)
+        protected override ReadOnlyMemory<byte> SignInternal(KerberosKey key)
         {
             var crypto = CryptoService.CreateTransform(EncryptionType.RC4_HMAC_NT);
 
@@ -102,7 +102,7 @@ namespace Kerberos.NET.Crypto
         {
             var actualChecksum = SignInternal(key);
 
-            return KerberosCryptoTransformer.AreEqualSlow(actualChecksum, Signature.Span);
+            return KerberosCryptoTransformer.AreEqualSlow(actualChecksum.Span, Signature.Span);
         }
     }
 }

--- a/Kerberos.NET/Crypto/RC4/MD4.cs
+++ b/Kerberos.NET/Crypto/RC4/MD4.cs
@@ -98,7 +98,7 @@ namespace Kerberos.NET.Crypto
 
         public int HashSize { get; }
 
-        public ReadOnlySpan<byte> ComputeHash(ReadOnlySpan<byte> data)
+        public ReadOnlyMemory<byte> ComputeHash(ReadOnlySpan<byte> data)
         {
             fixed (byte* pData = data)
             {
@@ -117,7 +117,7 @@ namespace Kerberos.NET.Crypto
                 throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 
-            return new ReadOnlySpan<byte>(hashValue);
+            return new ReadOnlyMemory<byte>(hashValue);
         }
 
         public void Dispose()

--- a/Kerberos.NET/Entities/GssApi/GssApiToken.cs
+++ b/Kerberos.NET/Entities/GssApi/GssApiToken.cs
@@ -36,7 +36,7 @@ namespace Kerberos.NET.Entities
 
                 writer.WriteObjectIdentifier(oid);
 
-                writer.WriteEncodedValue(token.Encode());
+                writer.WriteEncodedValue(token.Encode().Span);
 
                 writer.PopSequence(ApplicationTag);
 

--- a/Kerberos.NET/Entities/KerberosConstants.cs
+++ b/Kerberos.NET/Entities/KerberosConstants.cs
@@ -76,13 +76,13 @@ namespace Kerberos.NET.Entities
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<byte> UnicodeBytesToUtf8(byte[] str)
+        public static ReadOnlyMemory<byte> UnicodeBytesToUtf8(byte[] str)
         {
             return Encoding.Convert(Encoding.Unicode, Encoding.UTF8, str, 0, str.Length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<byte> UnicodeStringToUtf8(string str)
+        public static ReadOnlyMemory<byte> UnicodeStringToUtf8(string str)
         {
             return UnicodeBytesToUtf8(Encoding.Unicode.GetBytes(str));
         }

--- a/Kerberos.NET/Entities/Krb/KrbApRep.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApRep.generated.cs
@@ -17,13 +17,13 @@ namespace Kerberos.NET.Entities
         public MessageType MessageType;
         public KrbEncryptedData EncryptedPart;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -99,9 +99,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbApReq.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApReq.generated.cs
@@ -20,13 +20,13 @@ namespace Kerberos.NET.Entities
         public KrbTicket Ticket;
         public KrbEncryptedData Authenticator;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -108,9 +108,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbAsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsReq.cs
@@ -37,7 +37,7 @@ namespace Kerberos.NET.Entities
                 new KrbPaData
                 {
                     Type = PaDataType.PA_PAC_REQUEST,
-                    Value = pacRequest.Encode().AsMemory()
+                    Value = pacRequest.Encode()
                 }
             };
 
@@ -45,7 +45,7 @@ namespace Kerberos.NET.Entities
             {
                 var ts = KrbPaEncTsEnc.Now();
 
-                var tsEncoded = ts.Encode().AsMemory();
+                var tsEncoded = ts.Encode();
 
                 KrbEncryptedData encData = KrbEncryptedData.Encrypt(
                     tsEncoded,
@@ -56,7 +56,7 @@ namespace Kerberos.NET.Entities
                 padata.Add(new KrbPaData
                 {
                     Type = PaDataType.PA_ENC_TIMESTAMP,
-                    Value = encData.Encode().AsMemory()
+                    Value = encData.Encode()
                 });
             }
 

--- a/Kerberos.NET/Entities/Krb/KrbAuthenticator.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAuthenticator.generated.cs
@@ -24,13 +24,13 @@ namespace Kerberos.NET.Entities
         public int? SequenceNumber;
         public KrbAuthorizationData[] AuthorizationData;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -151,9 +151,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbAuthorizationData.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAuthorizationData.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public AuthorizationDataType Type;
         public ReadOnlyMemory<byte> Data;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbAuthorizationDataSequence.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAuthorizationDataSequence.generated.cs
@@ -32,13 +32,13 @@ namespace Kerberos.NET.Entities
             ensureUniqueTag(Asn1Tag.Sequence, "AuthorizationData");
         }
 #endif
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -77,9 +77,7 @@ namespace Kerberos.NET.Entities
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbChecksum.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbChecksum.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public ChecksumType Type;
         public ReadOnlyMemory<byte> Checksum;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbCred.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbCred.generated.cs
@@ -19,13 +19,13 @@ namespace Kerberos.NET.Entities
         public KrbTicket[] Tickets;
         public KrbEncryptedData EncryptedPart;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -111,9 +111,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbCredInfo.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbCredInfo.generated.cs
@@ -27,13 +27,13 @@ namespace Kerberos.NET.Entities
         public KrbPrincipalName SName;
         public KrbAuthorizationData[] AuthorizationData;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -155,9 +155,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbETypeInfo2.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbETypeInfo2.generated.cs
@@ -32,13 +32,13 @@ namespace Kerberos.NET.Entities
             ensureUniqueTag(Asn1Tag.Sequence, "ETypeInfo");
         }
 #endif
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -77,9 +77,7 @@ namespace Kerberos.NET.Entities
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbETypeInfo2Entry.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbETypeInfo2Entry.generated.cs
@@ -17,13 +17,13 @@ namespace Kerberos.NET.Entities
         public string Salt;
         public ReadOnlyMemory<byte>? S2kParams;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -79,9 +79,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbETypeList.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbETypeList.generated.cs
@@ -32,13 +32,13 @@ namespace Kerberos.NET.Entities
             ensureUniqueTag(Asn1Tag.Sequence, "List");
         }
 #endif
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -77,9 +77,7 @@ namespace Kerberos.NET.Entities
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncApRepPart.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncApRepPart.generated.cs
@@ -18,13 +18,13 @@ namespace Kerberos.NET.Entities
         public KrbEncryptionKey SubSessionKey;
         public int? SequenceNumber;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -113,9 +113,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncKdcRepPart.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncKdcRepPart.generated.cs
@@ -29,13 +29,13 @@ namespace Kerberos.NET.Entities
         public KrbHostAddress[] CAddr;
         public KrbMethodData EncryptedPaData;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -150,9 +150,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncKrbCredPart.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncKrbCredPart.generated.cs
@@ -21,13 +21,13 @@ namespace Kerberos.NET.Entities
         public KrbHostAddress SAddress;
         public KrbHostAddress RAddress;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -144,9 +144,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncTicketPart.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncTicketPart.generated.cs
@@ -27,13 +27,13 @@ namespace Kerberos.NET.Entities
         public KrbHostAddress[] CAddr;
         public KrbAuthorizationData[] AuthorizationData;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -167,9 +167,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncryptedData.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncryptedData.cs
@@ -11,7 +11,7 @@ namespace Kerberos.NET.Entities
 
             var decrypted = crypto.Decrypt(this.Cipher, key, usage);
 
-            return func(decrypted.AsMemory());
+            return func(decrypted);
         }
 
         public static KrbEncryptedData Encrypt(ReadOnlyMemory<byte> data, KerberosKey key, KeyUsage usage)

--- a/Kerberos.NET/Entities/Krb/KrbEncryptedData.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncryptedData.generated.cs
@@ -17,13 +17,13 @@ namespace Kerberos.NET.Entities
         public int? KeyVersionNumber;
         public ReadOnlyMemory<byte> Cipher;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -74,9 +74,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbEncryptionKey.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncryptionKey.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public EncryptionType EType;
         public ReadOnlyMemory<byte> KeyValue;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbError.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbError.generated.cs
@@ -27,13 +27,13 @@ namespace Kerberos.NET.Entities
         public string EText;
         public ReadOnlyMemory<byte>? EData;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -169,9 +169,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbHostAddress.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbHostAddress.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public AddressType AddressType;
         public ReadOnlyMemory<byte> Address;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -196,7 +196,7 @@ namespace Kerberos.NET.Entities
                 authz.Add(new KrbAuthorizationData
                 {
                     Type = AuthorizationDataType.AdIfRelevant,
-                    Data = sequence.Encode().AsMemory()
+                    Data = sequence.Encode()
                 });
             }
 

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.generated.cs
@@ -22,13 +22,13 @@ namespace Kerberos.NET.Entities
         public KrbTicket Ticket;
         public KrbEncryptedData EncPart;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -98,9 +98,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbKdcReq.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcReq.generated.cs
@@ -19,13 +19,13 @@ namespace Kerberos.NET.Entities
         public KrbPaData[] PaData;
         public KrbKdcReqBody Body;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -81,9 +81,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbKdcReqBody.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcReqBody.generated.cs
@@ -28,13 +28,13 @@ namespace Kerberos.NET.Entities
         public KrbEncryptedData EncAuthorizationData;
         public KrbTicket[] AdditionalTickets;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -163,9 +163,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbLastReq.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbLastReq.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public int Type;
         public DateTimeOffset Value;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbMethodData.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbMethodData.generated.cs
@@ -32,13 +32,13 @@ namespace Kerberos.NET.Entities
             ensureUniqueTag(Asn1Tag.Sequence, "MethodData");
         }
 #endif
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -77,9 +77,7 @@ namespace Kerberos.NET.Entities
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPaData.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaData.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public PaDataType Type;
         public ReadOnlyMemory<byte> Value;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPaEncTsEnc.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaEncTsEnc.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public DateTimeOffset PaTimestamp;
         public int? PaUSec;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -70,9 +70,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPaForUser.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaForUser.cs
@@ -56,7 +56,7 @@ namespace Kerberos.NET.Entities
 
         private static void Concat(Memory<byte> checksumData, ref int position, ref string value)
         {
-            KerberosConstants.UnicodeStringToUtf8(value).CopyTo(checksumData.Span.Slice(position, value.Length));
+            KerberosConstants.UnicodeStringToUtf8(value).CopyTo(checksumData.Slice(position, value.Length));
 
             position += value.Length;
         }

--- a/Kerberos.NET/Entities/Krb/KrbPaForUser.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaForUser.generated.cs
@@ -18,13 +18,13 @@ namespace Kerberos.NET.Entities
         public KrbChecksum Checksum;
         public string AuthPackage;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -73,9 +73,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPaPacOptions.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaPacOptions.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public PacOptions Flags;
     
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -62,9 +62,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPaPacRequest.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPaPacRequest.generated.cs
@@ -15,13 +15,13 @@ namespace Kerberos.NET.Entities
     {
         public bool IncludePac;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -61,9 +61,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbPrincipalName.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPrincipalName.generated.cs
@@ -17,13 +17,13 @@ namespace Kerberos.NET.Entities
         public PrincipalNameType Type;
         public string[] Name;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -73,9 +73,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
@@ -73,7 +73,7 @@ namespace Kerberos.NET.Entities
             }
 
             var bodyChecksum = KrbChecksum.Create(
-                body.Encode().AsMemory(),
+                body.Encode(),
                 tgtSessionKey.AsKey(),
                 KeyUsage.PaTgsReqChecksum
             );
@@ -92,7 +92,7 @@ namespace Kerberos.NET.Entities
                 },
                 new KrbPaData {
                     Type = PaDataType.PA_PAC_OPTIONS,
-                    Value = pacOptions.AsMemory()
+                    Value = pacOptions
                 }
             };
 
@@ -125,7 +125,7 @@ namespace Kerberos.NET.Entities
 
             paS4u.GenerateChecksum(sessionKey.AsKey());
 
-            return paS4u.Encode().AsMemory();
+            return paS4u.Encode();
         }
 
         private static KrbApReq CreateApReq(KrbKdcRep kdcRep, KrbEncryptionKey tgtSessionKey, KrbChecksum checksum, out KrbEncryptionKey subkey)

--- a/Kerberos.NET/Entities/Krb/KrbTicket.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTicket.generated.cs
@@ -18,13 +18,13 @@ namespace Kerberos.NET.Entities
         public KrbPrincipalName SName;
         public KrbEncryptedData EncryptedPart;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -103,9 +103,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/Krb/KrbTransitedEncoding.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTransitedEncoding.generated.cs
@@ -16,13 +16,13 @@ namespace Kerberos.NET.Entities
         public TransitedEncodingType Type;
         public ReadOnlyMemory<byte> Contents;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -65,9 +65,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/SpNego/NegTokenInit.generated.cs
+++ b/Kerberos.NET/Entities/SpNego/NegTokenInit.generated.cs
@@ -20,13 +20,13 @@ namespace Kerberos.NET.Entities
         public ReadOnlyMemory<byte>? MechToken;
         public ReadOnlyMemory<byte>? MechListMic;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -97,9 +97,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/SpNego/NegTokenResp.generated.cs
+++ b/Kerberos.NET/Entities/SpNego/NegTokenResp.generated.cs
@@ -18,13 +18,13 @@ namespace Kerberos.NET.Entities
         public ReadOnlyMemory<byte>? ResponseToken;
         public ReadOnlyMemory<byte>? MechListMic;
       
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
         
         internal void Encode(AsnWriter writer)
@@ -93,9 +93,7 @@ namespace Kerberos.NET.Entities
             {
                 EncodeApplication(writer, tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Entities/SpNego/NegotiationToken.generated.cs
+++ b/Kerberos.NET/Entities/SpNego/NegotiationToken.generated.cs
@@ -33,13 +33,13 @@ namespace Kerberos.NET.Entities
             ensureUniqueTag(new Asn1Tag(TagClass.ContextSpecific, 1), "ResponseToken");
         }
 #endif
-        public ReadOnlySpan<byte> Encode()
+        public ReadOnlyMemory<byte> Encode()
         {
             var writer = new AsnWriter(AsnEncodingRules.DER);
 
             Encode(writer);
 
-            return writer.EncodeAsSpan();
+            return writer.EncodeAsMemory();
         }
 
         internal void Encode(AsnWriter writer)
@@ -84,9 +84,7 @@ namespace Kerberos.NET.Entities
 
                 writer.PopSequence(tag);
 
-                var span = writer.EncodeAsSpan();
-
-                return span.AsMemory();
+                return writer.EncodeAsMemory();
             }
         }
         

--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -147,7 +147,7 @@ namespace Kerberos.NET.Server
                 EData = new KrbMethodData
                 {
                     MethodData = preAuthRequests.ToArray()
-                }.Encode().AsMemory()
+                }.Encode()
             };
 
             return err.EncodeApplication();

--- a/Kerberos.NET/Server/PaDataETypeInfo2Handler.cs
+++ b/Kerberos.NET/Server/PaDataETypeInfo2Handler.cs
@@ -36,7 +36,7 @@ namespace Kerberos.NET.Server
             var infoPaData = new KrbPaData
             {
                 Type = PaDataType.PA_ETYPE_INFO2,
-                Value = etypeInfo.Encode().AsMemory()
+                Value = etypeInfo.Encode()
             };
 
             preAuthRequirements.Add(infoPaData);

--- a/Tests/Tests.Kerberos.NET/Crypto/CryptoTests.cs
+++ b/Tests/Tests.Kerberos.NET/Crypto/CryptoTests.cs
@@ -1,4 +1,4 @@
-using Kerberos.NET;
+﻿using Kerberos.NET;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -33,7 +33,7 @@ namespace Tests.Kerberos.NET
 
             var decrypted = aesTransformer.Decrypt(encrypted, key, KeyUsage.PaEncTs);
 
-            Assert.IsTrue(data.Span.SequenceEqual(decrypted));
+            Assert.IsTrue(data.Span.SequenceEqual(decrypted.Span));
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace Tests.Kerberos.NET
 
             var decrypted = aesTransformer.Decrypt(encrypted, key, KeyUsage.PaEncTs);
 
-            Assert.IsTrue(data.Span.SequenceEqual(decrypted));
+            Assert.IsTrue(data.Span.SequenceEqual(decrypted.Span));
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Tests.Kerberos.NET
 
             var decrypted = rc4Transformer.Decrypt(encrypted, key, KeyUsage.PaEncTs);
 
-            Assert.IsTrue(data.Span.SequenceEqual(decrypted));
+            Assert.IsTrue(data.Span.SequenceEqual(decrypted.Span));
         }
 
         [TestMethod]
@@ -208,7 +208,7 @@ namespace Tests.Kerberos.NET
 
             var gen = key.GetKey();
 
-            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(gen, expectedKey));
+            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(gen.Span, expectedKey));
         }
 
         [TestMethod]
@@ -234,7 +234,7 @@ namespace Tests.Kerberos.NET
 
             var upperCase = upperCaseKey.GetKey();
 
-            Assert.IsFalse(KerberosCryptoTransformer.AreEqualSlow(lowerCase, upperCase));
+            Assert.IsFalse(KerberosCryptoTransformer.AreEqualSlow(lowerCase.Span, upperCase.Span));
         }
 
         [TestMethod]
@@ -271,7 +271,7 @@ namespace Tests.Kerberos.NET
 
             var gen = key.GetKey();
 
-            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(gen, expectedKey));
+            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(gen.Span, expectedKey));
         }
 
         [TestMethod]
@@ -351,7 +351,7 @@ namespace Tests.Kerberos.NET
 
             var fixedKey = keyFixedSalt.GetKey();
 
-            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(fixedKey, expectedKey));
+            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(fixedKey.Span, expectedKey));
 
             var keyDerivedSalt = new KerberosKey(
                 password: password,
@@ -363,7 +363,7 @@ namespace Tests.Kerberos.NET
 
             var derived = keyDerivedSalt.GetKey();
 
-            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(derived, expectedKey));
+            Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(derived.Span, expectedKey));
         }
 
         private static async Task AssertDecode(byte[] data, byte[] key, EncryptionType etype)

--- a/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
@@ -143,7 +143,7 @@ namespace Tests.Kerberos.NET
 
             var encoded = encPart.Encode();
 
-            var decoded = KrbEncApRepPart.DecodeApplication(encoded.AsMemory());
+            var decoded = KrbEncApRepPart.DecodeApplication(encoded);
 
             Assert.IsNotNull(decoded);
         }

--- a/Tests/Tests.Kerberos.NET/Messages/KrbAsReqTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbAsReqTests.cs
@@ -88,12 +88,12 @@ namespace Tests.Kerberos.NET
             var tsEncoded = ts.Encode();
 
             KrbEncryptedData encData = KrbEncryptedData.Encrypt(
-                tsEncoded.AsMemory(),
+                tsEncoded,
                 key,
                 KeyUsage.PaEncTs
             );
 
-            Assert.IsTrue(tsEncoded.SequenceEqual(encData.Decrypt(key, KeyUsage.PaEncTs, d => KrbPaEncTsEnc.Decode(d)).Encode()));
+            Assert.IsTrue(tsEncoded.Span.SequenceEqual(encData.Decrypt(key, KeyUsage.PaEncTs, d => KrbPaEncTsEnc.Decode(d)).Encode().Span));
 
             var asreq = new KrbAsReq()
             {

--- a/Tests/Tests.Kerberos.NET/Messages/KrbErrorTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbErrorTests.cs
@@ -70,7 +70,7 @@ namespace Tests.Kerberos.NET
 
             var encoded = err.Encode();
 
-            var decoded = KrbError.DecodeApplication(encoded.AsMemory());
+            var decoded = KrbError.DecodeApplication(encoded);
 
             Assert.IsNotNull(decoded);
 

--- a/Tests/Tests.Kerberos.NET/Ntlm/NtlmTests.cs
+++ b/Tests/Tests.Kerberos.NET/Ntlm/NtlmTests.cs
@@ -74,7 +74,7 @@ namespace Tests.Kerberos.NET
 
             var encoded = negToken.Encode();
 
-            var decoded = NegotiationToken.Decode(encoded.AsMemory());
+            var decoded = NegotiationToken.Decode(encoded);
 
             Assert.IsNotNull(decoded);
             Assert.IsNotNull(decoded.InitialToken);
@@ -96,7 +96,7 @@ namespace Tests.Kerberos.NET
 
             var encoded = negToken.Encode();
 
-            var decoded = NegotiationToken.Decode(encoded.AsMemory());
+            var decoded = NegotiationToken.Decode(encoded);
 
             Assert.IsNotNull(decoded);
             Assert.IsNull(decoded.InitialToken);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1",
+  "version": "3.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with rel/vN.N


### PR DESCRIPTION
This prevents having to always call `AsMemory()` for any serialization work and reduces all the copying used in the crypto paths.
This also converts the allocate-and-trash paths to rent-and-return to reduce fragmentation.
This a significant enough modification of the API that it needs a version bump.