### PR TITLE
Realm referrals can sometimes be redundant from the clients perspective

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -377,7 +377,8 @@ namespace Kerberos.NET.Client
 
                         string referral = TryFindReferralShortcut(encKdcRepPart);
 
-                        if (string.IsNullOrWhiteSpace(referral))
+                        if (string.IsNullOrWhiteSpace(referral) ||
+                            encKdcRepPart.SName.Matches(KrbPrincipalName.FromString(referral, PrincipalNameType.NT_SRV_INST)))
                         {
                             referral = originalServicePrincipalName.FullyQualifiedName;
                         }


### PR DESCRIPTION
### What's the problem?

Windows will return a referral shortcut if it thinks it knows what realm can fulfill the request. If the shortcut is a single hop it'll return the same SName as in the response. This causes the client library to request krbtgt/realm from the realm in question, instead of just asking for the final ticket.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Check if the shortcut matches the name in the response, and ignore it if it does.

Describe the solution here.

 - [ ] Includes unit tests
 - [X] Requires manual test
