### PR TITLE
Handled no DNS support and fixed path issue

### DIFF
--- a/Kerberos.NET/Client/Transport/ClientDomainService.cs
+++ b/Kerberos.NET/Client/Transport/ClientDomainService.cs
@@ -124,7 +124,14 @@ namespace Kerberos.NET.Transport
 
             if (this.Configuration.Defaults.DnsLookupKdc)
             {
-                await QueryDns(domain, servicePrefix, records);
+                try
+                {
+                    await QueryDns(domain, servicePrefix, records);
+                }
+                catch (DnsNotSupportedException ex)
+                {
+                    this.logger.LogDebug(ex, "DNS isn't supported on this platform");
+                }
             }
 
             return records;

--- a/Kerberos.NET/CommandLine/KerberosListCommand.cs
+++ b/Kerberos.NET/CommandLine/KerberosListCommand.cs
@@ -88,7 +88,19 @@ namespace Kerberos.NET.CommandLine
             }
             catch (AggregateException aex)
             {
-                foreach (var kex in aex.InnerExceptions.OfType<KerberosProtocolException>())
+                ICollection<Exception> exceptions = aex.InnerExceptions;
+
+                if (exceptions == null)
+                {
+                    exceptions = new List<Exception>();
+
+                    if (aex.InnerException != null)
+                    {
+                        exceptions.Add(aex.InnerException);
+                    }
+                }
+
+                foreach (var kex in exceptions.OfType<KerberosProtocolException>())
                 {
                     if (kex.Error.ErrorCode == KerberosErrorCode.KRB_AP_ERR_TKT_EXPIRED)
                     {
@@ -96,6 +108,8 @@ namespace Kerberos.NET.CommandLine
                         await client.GetServiceTicket(this.ServicePrincipalName);
                         break;
                     }
+
+                    this.IO.Writer.WriteLine(kex.Message);
                 }
             }
         }

--- a/Kerberos.NET/Configuration/Krb5Config.cs
+++ b/Kerberos.NET/Configuration/Krb5Config.cs
@@ -63,7 +63,31 @@ namespace Kerberos.NET.Configuration
         public Krb5Logging Logging { get; private set; }
 
         public static string UserConfigurationPath
-            => Environment.ExpandEnvironmentVariables("%APPDATA%\\Kerberos.NET\\");
+        {
+            get
+            {
+                var config = Environment.ExpandEnvironmentVariables("%KRB5_CONFIG%");
+
+                if (!string.IsNullOrWhiteSpace(config) && !"%KRB5_CONFIG%".Equals(config, StringComparison.Ordinal))
+                {
+                    return config;
+                }
+                else if (OSPlatform.IsWindows)
+                {
+                    return Environment.ExpandEnvironmentVariables("%APPDATA%\\Kerberos.NET\\");
+                }
+                else if (OSPlatform.IsOsX)
+                {
+                    return "Library/Preferences/Kerberos.NET/";
+                }
+                else if (OSPlatform.IsLinux)
+                {
+                    return "/etc/";
+                }
+
+                return string.Empty;
+            }
+        }
 
         public static string DefaultUserConfiguration => Path.Combine(UserConfigurationPath, "krb5.conf");
 

--- a/Kerberos.NET/Dns/DnsNotSupportedException.cs
+++ b/Kerberos.NET/Dns/DnsNotSupportedException.cs
@@ -1,0 +1,34 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Kerberos.NET.Dns
+{
+
+    [Serializable]
+    public class DnsNotSupportedException : Exception
+    {
+        public DnsNotSupportedException()
+        {
+        }
+
+        public DnsNotSupportedException(string message)
+            : base(message)
+        {
+        }
+
+        public DnsNotSupportedException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected DnsNotSupportedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Kerberos.NET/Dns/DnsQuery.cs
+++ b/Kerberos.NET/Dns/DnsQuery.cs
@@ -60,7 +60,7 @@ namespace Kerberos.NET.Dns
 
             if (implementation == null)
             {
-                throw new InvalidOperationException("DNS Query implementation cannot be null");
+                throw new DnsNotSupportedException("DNS Query implementation cannot be null");
             }
 
             if (Debug)


### PR DESCRIPTION
### What's the problem?

DNS isn't supported on Mac or Linux yet, but this causes all requests to fail. Config pathing incorrectly picks the wrong location on non-Windows platforms so you can't turn it off.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Handle the error and fix the pathing.

 - [ ] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Provide the issue ID if there's a related issue.
