### PR TITLE
Make the default instance of config smart

### DIFF
--- a/Kerberos.NET/Configuration/ConfigurationSectionList.cs
+++ b/Kerberos.NET/Configuration/ConfigurationSectionList.cs
@@ -39,6 +39,8 @@ namespace Kerberos.NET.Configuration
                                       EncryptionType.AES256_CTS_HMAC_SHA1_96) },
         };
 
+        internal static readonly ConfigurationSectionList Default = Krb5ConfigurationSerializer.Deserialize(string.Empty);
+
         private readonly List<string> finalizedKeys = new List<string>();
 
         /// <summary>
@@ -294,9 +296,12 @@ namespace Kerberos.NET.Configuration
         /// Converts the list of values into a structured <see cref="Krb5Config" /> configuration instance.
         /// </summary>
         /// <returns>Returns a configuration instance.</returns>
-        public Krb5Config ToConfigObject()
+        public Krb5Config ToConfigObject(Krb5Config config = null)
         {
-            var config = new Krb5Config();
+            if (config is null)
+            {
+                config = new Krb5Config();
+            }
 
             var properties = config.GetType().GetProperties(PublicInstancePropertyFlags);
 

--- a/Kerberos.NET/Configuration/Krb5Config.cs
+++ b/Kerberos.NET/Configuration/Krb5Config.cs
@@ -16,6 +16,11 @@ namespace Kerberos.NET.Configuration
     /// </summary>
     public class Krb5Config
     {
+        public Krb5Config()
+        {
+            ConfigurationSectionList.Default.ToConfigObject(this);
+        }
+
         /// <summary>
         /// System defaults that will be used if the protocol or client do not provide explicit values.
         /// </summary>
@@ -112,7 +117,7 @@ namespace Kerberos.NET.Configuration
 
         public static Krb5Config Default()
         {
-            return Krb5ConfigurationSerializer.Deserialize(string.Empty).ToConfigObject();
+            return new Krb5Config();
         }
 
         public string Serialize()

--- a/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
+++ b/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
@@ -123,6 +123,14 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public void DefaultWithNewCtor()
+        {
+            var config = new Krb5Config();
+
+            Assert.AreEqual(5, config.Defaults.DefaultTgsEncTypes.Count());
+        }
+
+        [TestMethod]
         public void TraverseQuotedSettings()
         {
             var conf = ParseConfiguration();


### PR DESCRIPTION
### What's the problem?

Describe the problem here.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Creating a new config object doesn't set defaults. It should set defaults.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #205 
