### PR TITLE
A cache miss can corrupt the dictionary when used concurrently so swi…

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/Kerberos.NET/Crypto/CryptoService.cs
+++ b/Kerberos.NET/Crypto/CryptoService.cs
@@ -1,9 +1,10 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using ChecksumConstructor = System.Func<System.ReadOnlyMemory<byte>, System.ReadOnlyMemory<byte>, Kerberos.NET.Crypto.KerberosChecksum>;
 
@@ -16,6 +17,9 @@ namespace Kerberos.NET.Crypto
 
         private static readonly Dictionary<ChecksumType, ChecksumConstructor> ChecksumAlgorithms
             = new Dictionary<ChecksumType, ChecksumConstructor>();
+
+        private static readonly ConcurrentDictionary<EncryptionType, ChecksumType> ETypeToChecksumCache
+            = new ConcurrentDictionary<EncryptionType, ChecksumType>();
 
         static CryptoService()
         {
@@ -72,11 +76,9 @@ namespace Kerberos.NET.Crypto
             return CryptoAlgorithms.ContainsKey(etype);
         }
 
-        private static readonly Dictionary<EncryptionType, ChecksumType> Cache = new Dictionary<EncryptionType, ChecksumType>();
-
         internal static ChecksumType ConvertType(EncryptionType type)
         {
-            if (Cache.TryGetValue(type, out ChecksumType checksumType))
+            if (ETypeToChecksumCache.TryGetValue(type, out ChecksumType checksumType))
             {
                 return checksumType;
             }
@@ -107,7 +109,7 @@ namespace Kerberos.NET.Crypto
                     break;
             }
 
-            Cache[type] = checksumType;
+            ETypeToChecksumCache.TryAdd(type, checksumType);
 
             return checksumType;
         }

--- a/build.yaml
+++ b/build.yaml
@@ -23,7 +23,7 @@ stages:
     - task: UseDotNet@2
       displayName: 'Use .NET Core SDK 3.1.x'
       inputs:
-        version: 3.1.302
+        version: 5.x
         performMultiLevelLookup: true
 
     - task: DotNetCoreCLI@2


### PR DESCRIPTION
…tch to a dict that can handle it

### What's the problem?

We cache the type to checksum mapping for quick retrieval, but when a new etype shows up we need to figure out the mapped checksum type. Eventually this gets cached, and if this occurs under heavy concurrency it'll corrupt the dictionary.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Switch to concurrent dictionary for cache.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Fixes https://github.com/dotnet/Kerberos.NET/issues/216
