### PR TITLE
Fixes #221

### DIFF
--- a/Kerberos.NET/Client/Transport/ClientDomainService.cs
+++ b/Kerberos.NET/Client/Transport/ClientDomainService.cs
@@ -174,7 +174,7 @@ namespace Kerberos.NET.Transport
 
         private static DnsRecord ParseKdcEntryAsSrvRecord(string kdc, string realm, string servicePrefix)
         {
-            if (Uri.TryCreate(kdc, UriKind.Absolute, out _))
+            if (IsUri(kdc))
             {
                 return new DnsRecord
                 {
@@ -203,6 +203,13 @@ namespace Kerberos.NET.Transport
             }
 
             return record;
+        }
+
+        private static bool IsUri(string kdc)
+        {
+            return Uri.TryCreate(kdc, UriKind.Absolute, out Uri result) &&
+                ("https".Equals(result.Scheme, StringComparison.OrdinalIgnoreCase) ||
+                 "http".Equals(result.Scheme, StringComparison.OrdinalIgnoreCase));
         }
 
         private static async Task MonitorDnsCache()


### PR DESCRIPTION
Added check to make sure URI.TryCreate actually returns a usable URI.

### What's the problem?

Uri.TryCreate is a little too ambitious in what it thinks is a URI.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Verify the URI is something we can actually use before treating it as a URI.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #221.
