### PR TITLE
Added AS ping

### DIFF
--- a/Bruce/BruceConsoleShell.cs
+++ b/Bruce/BruceConsoleShell.cs
@@ -181,8 +181,12 @@ namespace Kerberos.NET.CommandLine
 
             if (!executed)
             {
+                this.io.Writer.WriteLine();
+
                 command?.DisplayHelp();
             }
+
+            this.io.Writer.WriteLine();
         }
 
         private bool TryProcessSystemCommand(CommandLineParameters parameters, out bool exiting)

--- a/Bruce/CommandLine/BaseCommand.cs
+++ b/Bruce/CommandLine/BaseCommand.cs
@@ -59,7 +59,7 @@ namespace Kerberos.NET.CommandLine
             return new KerberosClient(config, logger) { CacheInMemory = false };
         }
 
-        private ILoggerFactory CreateVerboseLogger()
+        protected ILoggerFactory CreateVerboseLogger()
         {
             return new KerberosDelegateLogger(
                 (level, cateogry, id, scopeState, logState, exception, log)

--- a/Bruce/CommandLine/KerberosPingCommand.cs
+++ b/Bruce/CommandLine/KerberosPingCommand.cs
@@ -1,0 +1,215 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Kerberos.NET.Client;
+using Kerberos.NET.Credentials;
+using Kerberos.NET.Crypto;
+using Kerberos.NET.Entities;
+using Kerberos.NET.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Kerberos.NET.CommandLine
+{
+    [CommandLineCommand("kping", Description = "KerberosPing")]
+    public class KerberosPing : BaseCommand
+    {
+        public KerberosPing(CommandLineParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        [CommandLineParameter("principal",
+            FormalParameter = true,
+            Required = true,
+            Description = "UserPrincipalName")]
+        public string UserPrincipalName { get; set; }
+
+        [CommandLineParameter("verbose", Description = "Verbose")]
+        public bool Verbose { get; protected set; }
+
+        public override async Task<bool> Execute()
+        {
+            if (await base.Execute())
+            {
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(this.UserPrincipalName))
+            {
+                return false;
+            }
+
+            this.IO.Writer.WriteLine();
+
+            var client = this.CreateClient(verbose: this.Verbose);
+            var logger = this.Verbose ? CreateVerboseLogger() : NullLoggerFactory.Instance;
+
+            ILogger infoLogger = this.Verbose ? logger.CreateLogger("Information") : CreateVerboseLogger().CreateLogger("Information");
+            ILogger errorLogger = this.Verbose ? logger.CreateLogger("Error") : CreateVerboseLogger().CreateLogger("Error");
+
+            var credential = new KerberosPasswordCredential(this.UserPrincipalName, "password not required for this");
+
+            if (string.IsNullOrWhiteSpace(credential.UserName))
+            {
+                errorLogger.LogWarning("UserPrincipalName is required");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(credential.Domain))
+            {
+                errorLogger.LogWarning("Domain could not be determined from username '{UserName}'", credential.UserName);
+                return false;
+            }
+
+            var asReqMessage = KrbAsReq.CreateAsReq(credential, AuthenticationOptions.Renewable);
+
+            var asReq = asReqMessage.EncodeApplication();
+
+            var transport = new KerberosTransportSelector(
+                new IKerberosTransport[]
+                {
+                    new TcpKerberosTransport(logger),
+                    new UdpKerberosTransport(logger),
+                    new HttpsKerberosTransport(logger)
+                },
+                client.Configuration,
+                logger
+            )
+            {
+                ConnectTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            try
+            {
+                var asRep = await transport.SendMessage<KrbAsRep>(credential.Domain, asReq);
+
+                if (asRep?.Ticket != null)
+                {
+                    errorLogger.LogError("Danger: The principal {PrincipalName} does not require pre-authentication", asRep.CName.FullyQualifiedName);
+                    errorLogger.LogError("Pre-authentication should be enabled ASAP");
+                }
+            }
+            catch (KerberosProtocolException pex)
+            {
+                WritePreAuthRequirement(infoLogger, credential, pex);
+            }
+            catch (AggregateException gex)
+            {
+                WriteFailure(logger, gex);
+            }
+
+            return true;
+        }
+
+        private void WriteFailure(ILoggerFactory logger, AggregateException gex)
+        {
+            if (this.Verbose)
+            {
+                this.IO.Writer.WriteLine();
+            }
+
+            ILogger errorLog;
+
+            if (this.Verbose)
+            {
+                errorLog = logger.CreateLogger("Error");
+            }
+            else
+            {
+                errorLog = CreateVerboseLogger().CreateLogger("Error");
+            }
+
+            foreach (var ex in gex.InnerExceptions)
+            {
+                errorLog.LogDebug(ex.Message);
+            }
+        }
+
+        private void WritePreAuthRequirement(ILogger infoLogger, KerberosPasswordCredential credential, KerberosProtocolException pex)
+        {
+            if (this.Verbose)
+            {
+                this.IO.Writer.WriteLine();
+            }
+
+            var errorCode = pex.Error.ErrorCode;
+
+            infoLogger.LogInformation("{ErrorCode}: {ErrorText}", pex.Error.ErrorCode, pex.Error.EText.Replace(pex.Error.ErrorCode.ToString() + ": ", ""));
+            infoLogger.LogInformation("");
+
+            if (!string.IsNullOrWhiteSpace(pex.Error.Realm))
+            {
+                infoLogger.LogInformation("\tRealm: {Realm}", pex.Error.Realm);
+            }
+
+            if (pex.Error.CName != null)
+            {
+                infoLogger.LogInformation("\tClient: {CName}", pex.Error.CName.FullyQualifiedName);
+            }
+
+            if (pex.Error.SName != null)
+            {
+                infoLogger.LogInformation("\tServer: {SName}", pex.Error.SName.FullyQualifiedName);
+            }
+
+            infoLogger.LogInformation("");
+
+            if (pex.Error.ErrorCode != KerberosErrorCode.KDC_ERR_PREAUTH_REQUIRED)
+            {
+                return;
+            }
+
+            var paData = pex?.Error?.DecodePreAuthentication();
+
+            if (paData != null)
+            {
+                foreach (var pa in paData)
+                {
+                    infoLogger.LogInformation("- PA-Data Type: {PAType} ({PATypeValue})", pa.Type, (int)pa.Type);
+
+                    if (pa.Type != PaDataType.PA_ETYPE_INFO2)
+                    {
+                        if (pa.Value.Length > 0)
+                        {
+                            Hex.DumpHex(pa.Value, str => infoLogger.LogInformation("\t {Value}", str), bytesPerLine: pa.Value.Length > 16 ? 16 : 8);
+                        }
+                        else
+                        {
+                            infoLogger.LogInformation("\t {PaValue}", (string)null);
+                        }
+
+                        infoLogger.LogInformation("");
+
+                        continue;
+                    }
+
+                    var etypeData = pa.DecodeETypeInfo2();
+
+                    infoLogger.LogInformation("");
+                    infoLogger.LogInformation("\t - KDC Supported ETypes for principal {PrincipalName}", credential.UserName);
+                    infoLogger.LogInformation("");
+
+                    foreach (var etype in etypeData)
+                    {
+                        string s2k = null;
+
+                        if (etype.S2kParams.HasValue)
+                        {
+                            s2k = Hex.DumpHex(etype.S2kParams.Value);
+                        }
+
+                        infoLogger.LogInformation("\t   Etype: {EType}", etype.EType);
+                        infoLogger.LogInformation("\t    Salt: {Salt}", etype.Salt);
+                        infoLogger.LogInformation("\t     S2K: {S2kParams}", s2k);
+                        infoLogger.LogInformation("");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Bruce/Strings.Designer.cs
+++ b/Bruce/Strings.Designer.cs
@@ -628,6 +628,15 @@ namespace Kerberos.NET.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Locate and ping a KDC for the provided user to get pre-auth details..
+        /// </summary>
+        internal static string CommandLine_KerberosPing {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Displays details about the current authenticated user..
         /// </summary>
         internal static string CommandLine_KerberosWhoAmI {

--- a/Bruce/Strings.resx
+++ b/Bruce/Strings.resx
@@ -306,6 +306,9 @@
   <data name="CommandLine_KerberosListCommand_Verbose" xml:space="preserve">
     <value>Displays all data about the cache.</value>
   </data>
+  <data name="CommandLine_KerberosPing" xml:space="preserve">
+    <value>Locate and ping a KDC for the provided user to get pre-auth details.</value>
+  </data>
   <data name="CommandLine_KerberosWhoAmI" xml:space="preserve">
     <value>Displays details about the current authenticated user.</value>
   </data>

--- a/Kerberos.NET/Crypto/Hex.cs
+++ b/Kerberos.NET/Crypto/Hex.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -18,6 +18,16 @@ namespace Kerberos.NET.Crypto
         public static string DumpHex(this ReadOnlyMemory<byte> bytes, int bytesPerLine = 16)
         {
             return HexDump(bytes.ToArray(), bytesPerLine);
+        }
+
+        public static void DumpHex(this ReadOnlyMemory<byte> bytes, Action<string> writeLine, int bytesPerLine = 16)
+        {
+            var lines = HexDump(bytes.ToArray(), bytesPerLine).Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var line in lines)
+            {
+                writeLine(line);
+            }
         }
 
         public static unsafe string DumpHex(this IntPtr pThing, uint length)

--- a/Tests/Tests.Kerberos.NET/CommandLine/CommandLineTests.cs
+++ b/Tests/Tests.Kerberos.NET/CommandLine/CommandLineTests.cs
@@ -114,7 +114,7 @@ namespace Tests.Kerberos.NET
             var types = LoadTypes();
             var io = InputControl.Default();
 
-            Assert.AreEqual(7, types.Count());
+            Assert.AreEqual(8, types.Count());
 
             foreach (var type in types)
             {


### PR DESCRIPTION
### What's the problem?

Should would be nice to be able to see pre-auth requirements for a user without having to pull out a debugger or a network trace.

- [ ] Bugfix
- [X] New Feature

### What's the solution?

Just do the ping and dump the results.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

N/A
