### PR TITLE
Fixes #203

### DIFF
--- a/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -147,12 +147,12 @@ namespace Kerberos.NET.Crypto
 
             if (validation.HasFlag(ValidationActions.ClientPrincipalIdentifier))
             {
-                this.ValidateClientPrincipalIdentifier(this.Authenticator.CName, this.Ticket.CName);
+                this.ValidateClientPrincipalIdentifier(this.Ticket.CName, this.Authenticator.CName);
             }
 
             if (validation.HasFlag(ValidationActions.Realm))
             {
-                this.ValidateRealm(this.token.Ticket.Realm, this.Authenticator.Realm);
+                this.ValidateRealm(this.Ticket.CRealm, this.Authenticator.Realm);
             }
 
             var now = this.Now();

--- a/Kerberos.NET/Crypto/DecryptedKrbMessage.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbMessage.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -95,7 +95,7 @@ namespace Kerberos.NET.Crypto
             {
                 throw new KerberosValidationException(
                     "Ticket CName " +
-                    $"({leftName.Type}: {leftName.Type})" +
+                    $"({leftName.Type}: {leftName.Name})" +
                     " does not match Authenticator CName " +
                     $"({rightName?.Type}: {rightName?.Name})",
                     nameof(KrbPrincipalName)

--- a/Tests/Tests.Kerberos.NET/CommandLine/KerberosInitCommandTests.cs
+++ b/Tests/Tests.Kerberos.NET/CommandLine/KerberosInitCommandTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Kerberos.NET.CommandLine;
@@ -14,7 +15,7 @@ namespace Tests.Kerberos.NET
     [TestClass]
     public class KerberosInitCommandTests : CommandLineTestBase
     {
-        private const string KInitParameters = "kinit -kdc {0} -c {2} --realm corp.identityintervention.com {1}";
+        private const string KInitParameters = "kinit --kdc {0} --cache {2} --realm corp.identityintervention.com {1}";
         protected const string AdminAtCorpUserName = "administrator@corp.identityintervention.com";
         protected const string FakeAdminAtCorpPassword = "P@ssw0rd!";
 
@@ -59,7 +60,7 @@ namespace Tests.Kerberos.NET
                     var output = io.Writer.ToString();
 
                     Assert.IsTrue(output.Contains("Ticket Count: 1"));
-                    Assert.IsTrue(output.Contains("administrator@corp.identityintervention.com @ CORP.IDENTITYINTERVENTION.COM"), output);
+                    Assert.IsTrue(output.Contains("administrator@corp.identityintervention.com @ CORP.IDENTITYINTERVENTION.COM", StringComparison.OrdinalIgnoreCase), output);
                 }
             }
             finally


### PR DESCRIPTION
### What's the problem?

Realm comparison was checking the wrong property and causing cross-realm referrals to fail.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Check the property on the internal encrypted portion of the ticket instead of the outer jacket.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #203 
