### PR TITLE
Added check to prevent caching of the S4U tickets

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -509,7 +509,7 @@ namespace Kerberos.NET.Client
             {
                 KrbEncTgsRepPart encKdcRepPart = null;
                 KrbEncryptionKey sessionKey;
-                KerberosClientCacheEntry serviceTicketCacheEntry;
+                KerberosClientCacheEntry serviceTicketCacheEntry = default;
 
                 if (this.KdcOptions == 0)
                 {
@@ -542,10 +542,13 @@ namespace Kerberos.NET.Client
 
                     // first of all, do we already have the ticket?
 
-                    serviceTicketCacheEntry = this.Cache.GetCacheItem<KerberosClientCacheEntry>(
-                        originalServicePrincipalName.FullyQualifiedName,
-                        rst.S4uTarget
-                    );
+                    if (rst.CanCacheTicket)
+                    {
+                        serviceTicketCacheEntry = this.Cache.GetCacheItem<KerberosClientCacheEntry>(
+                            originalServicePrincipalName.FullyQualifiedName,
+                            rst.S4uTarget
+                        );
+                    }
 
                     bool cacheResult = false;
 
@@ -634,7 +637,7 @@ namespace Kerberos.NET.Client
                         receivedRequestedTicket = true;
                     }
 
-                    if (cacheResult)
+                    if (cacheResult && rst.CanCacheTicket)
                     {
                         // regardless of what state we're in we got a valuable ticket
                         // that can be used in future requests

--- a/Kerberos.NET/Entities/RequestServiceTicket.cs
+++ b/Kerberos.NET/Entities/RequestServiceTicket.cs
@@ -75,6 +75,11 @@ namespace Kerberos.NET
         /// </summary>
         public bool? CacheTicket { get; set; }
 
+        public bool CanCacheTicket => this.CacheTicket ?? true &&
+                                      string.IsNullOrWhiteSpace(this.S4uTarget) &&
+                                      this.S4uTicket == null &&
+                                      this.S4uTargetCertificate == null;
+
         public override bool Equals(object obj)
         {
             if (obj is RequestServiceTicket rst)


### PR DESCRIPTION
### What's the problem?

S4U is incorrectly caching and using S4U'ed tickets, meaning the wrong ticket can get selected.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Don't cache or check the cache for S4U tickets.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Fixed #248 
