### PR TITLE
Ticket Signature PAC type handling

### DIFF
--- a/Kerberos.NET/Entities/Pac/PacType.cs
+++ b/Kerberos.NET/Entities/Pac/PacType.cs
@@ -19,6 +19,8 @@ namespace Kerberos.NET.Entities
         UPN_DOMAIN_INFO = 12,
         CLIENT_CLAIMS = 13,
         DEVICE_INFO = 14,
-        DEVICE_CLAIMS = 15
+        DEVICE_CLAIMS = 15,
+        
+        TICKET_CHECKSUM = 16
     }
 }

--- a/Kerberos.NET/Entities/Pac/PrivilegedAttributeCertificate.cs
+++ b/Kerberos.NET/Entities/Pac/PrivilegedAttributeCertificate.cs
@@ -114,6 +114,7 @@ namespace Kerberos.NET.Entities
 
             // { PacType.DEVICE_INFO, typeof(PacLogonInfo) },
             { PacType.DEVICE_CLAIMS, typeof(ClaimsSetMetadata) },
+            { PacType.TICKET_CHECKSUM, typeof(PacSignature) }
         };
 
         private readonly Dictionary<PacType, PacObject> attributes = new Dictionary<PacType, PacObject>();
@@ -141,7 +142,7 @@ namespace Kerberos.NET.Entities
             {
                 signature = this.ProcessSignature(sig, type);
 
-                if (!this.Mode.HasFlag(SignatureMode.Kdc) && type == PacType.PRIVILEGE_SERVER_CHECKSUM)
+                if (!this.Mode.HasFlag(SignatureMode.Kdc) && type == PacType.PRIVILEGE_SERVER_CHECKSUM || type == PacType.TICKET_CHECKSUM)
                 {
                     signature.Ignored = true;
                 }
@@ -163,6 +164,10 @@ namespace Kerberos.NET.Entities
             if (type == PacType.PRIVILEGE_SERVER_CHECKSUM)
             {
                 signature.SignatureData = this.ServerSignature.Signature;
+            }
+            else if (type == PacType.TICKET_CHECKSUM)
+            {
+                // The ticket itself is needed for the SignatureData
             }
             else
             {


### PR DESCRIPTION
### What's the problem?

Microsoft has updated [MS-PAC] in November 2020 to include another signature called Ticket Signature to address the Bronze Bit attack.
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/166d8064-c863-41e1-9c23-edaaa5f36962
This new Pac Type is generated from DCs that has the related patch and the current ParsePacType just ignore this PacType

- [ ] Bugfix
- [X] New Feature

### What's the solution?

The solution is to add the relevant PacType to the Enum and to parse it.
My solution is only partial because it doesn't include the code required for the Process Signature function as the ticket itself is needed to populate this value (as I understood) and I do not fully understand the significance of the SignatureData property

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Provide the issue ID if there's a related issue.
