### PR TITLE
Keytabs have holes denoted by negative length values

### DIFF
--- a/Kerberos.NET/Crypto/KeyTable.cs
+++ b/Kerberos.NET/Crypto/KeyTable.cs
@@ -43,7 +43,12 @@ namespace Kerberos.NET.Crypto
         {
             while (reader.BytesAvailable() > 0)
             {
-                this.Entries.Add(new KeyEntry(reader, this.KerberosVersion));
+                var entry = new KeyEntry(reader, this.KerberosVersion);
+
+                if (entry.Length > 0)
+                {
+                    this.Entries.Add(entry);
+                }
             }
         }
 

--- a/Tests/Tests.Kerberos.NET/Crypto/KeyTableTests.cs
+++ b/Tests/Tests.Kerberos.NET/Crypto/KeyTableTests.cs
@@ -106,6 +106,31 @@ namespace Tests.Kerberos.NET
             }
         }
 
+        [TestMethod]
+        public void EncodeDecodeEmptyKey()
+        {
+            var kt = new KeyTable(
+                new KerberosKey(key: new byte[16], etype: EncryptionType.AES128_CTS_HMAC_SHA1_96,
+                    principal: PrincipalName.FromKrbPrincipalName(KrbPrincipalName.FromString("user@domain.com"), "domain.com")),
+                null,
+                new KerberosKey(key: new byte[16], etype: EncryptionType.AES128_CTS_HMAC_SHA1_96,
+                    principal: PrincipalName.FromKrbPrincipalName(KrbPrincipalName.FromString("user@domain.com"), "domain.com"))
+            );
+
+            var buffer = new MemoryStream();
+
+            using (var writer = new BinaryWriter(buffer))
+            {
+                kt.Write(writer);
+            }
+
+            var arr = buffer.ToArray();
+
+            var kt2 = new KeyTable(arr);
+
+            Assert.AreEqual(2, kt2.Entries.Count);
+        }
+
         private static void AssertKeytablesAreEqual(KeyTable keytable, KeyTable secondKeyTable)
         {
             for (var i = 0; i < keytable.Entries.Count; i++)


### PR DESCRIPTION
### What's the problem?

Keytabs have empty holes in the file denoted by a length prefix of a negative value. We previously ignored the negative value and the binary reader failed to process it.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Handle the negative value and skip it.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #254 
