### PR TITLE
Expose session key to context caller

### DIFF
--- a/Kerberos.NET/Win32/NativeMethods.cs
+++ b/Kerberos.NET/Win32/NativeMethods.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -110,6 +110,13 @@ namespace Kerberos.NET.Win32
             ref SECURITY_HANDLE phContext,
             SecurityContextAttribute ulAttribute,
             ref SecPkgContext_SecString pBuffer
+        );
+
+        [DllImport(SECUR32, SetLastError = true, EntryPoint = "QueryContextAttributes", CharSet = CharSet.Unicode)]
+        internal static extern SecStatus QueryContextAttributesSession(
+            ref SECURITY_HANDLE phContext,
+            SecurityContextAttribute ulAttribute,
+            ref SecPkgContext_SessionKey pBuffer
         );
 
         [DllImport(SECUR32)]
@@ -543,6 +550,13 @@ namespace Kerberos.NET.Win32
         internal struct SecPkgContext_SecString
         {
             public void* sValue;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct SecPkgContext_SessionKey
+        {
+            public uint SessionKeyLength;
+            public void* SessionKey;
         }
     }
 }

--- a/Kerberos.NET/Win32/SecurityContextAttribute.cs
+++ b/Kerberos.NET/Win32/SecurityContextAttribute.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -13,6 +13,7 @@ namespace Kerberos.NET.Win32
         SECPKG_ATTR_DCE_INFO = 3,
         SECPKG_ATTR_STREAM_SIZES = 4,
         SECPKG_ATTR_AUTHORITY = 6,
+        SECPKG_ATTR_SESSION_KEY = 9,
         SECPKG_ATTR_PACKAGE_INFO = 10,
         SECPKG_ATTR_NEGOTIATION_INFO = 12,
         SECPKG_ATTR_UNIQUE_BINDINGS = 25,

--- a/Kerberos.NET/Win32/SspiContext.cs
+++ b/Kerberos.NET/Win32/SspiContext.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -23,9 +23,11 @@ namespace Kerberos.NET.Win32
             this.context = new SspiSecurityContext(Credential.Current(), package);
         }
 
-        public byte[] RequestToken()
+        public byte[] SessionKey => this.context.QueryContextAttributeSession();
+
+        public byte[] RequestToken(byte[] serverResponse = null)
         {
-            var status = this.context.InitializeSecurityContext(this.spn, null, out byte[] clientRequest);
+            var status = this.context.InitializeSecurityContext(this.spn, serverResponse, out byte[] clientRequest);
 
             if (status == ContextStatus.Error)
             {

--- a/Kerberos.NET/Win32/SspiSecurityContext.cs
+++ b/Kerberos.NET/Win32/SspiSecurityContext.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -102,6 +102,41 @@ namespace Kerberos.NET.Win32
             }
 
             return strValue;
+        }
+
+        public unsafe byte[] QueryContextAttributeSession()
+        {
+            SecPkgContext_SessionKey pBuffer = default;
+            SecStatus status;
+            byte[] bytes = null;
+            
+            RuntimeHelpers.PrepareConstrainedRegions();
+            try
+            {
+            }
+            finally
+            {
+                try
+                {
+                    status = QueryContextAttributesSession(ref this.securityContext, SecurityContextAttribute.SECPKG_ATTR_SESSION_KEY, ref pBuffer);
+
+                    if (status == SecStatus.SEC_E_OK)
+                    {
+                        bytes = new Span<byte>(pBuffer.SessionKey, (int)pBuffer.SessionKeyLength).ToArray();
+                    }
+                }
+                finally
+                {
+                    ThrowIfError(FreeContextBuffer(pBuffer.SessionKey));
+                }
+            }
+
+            if (status != SecStatus.SEC_E_UNSUPPORTED_FUNCTION && status > SecStatus.SEC_E_ERROR)
+            {
+                throw new Win32Exception((int)status);
+            }
+
+            return bytes;
         }
 
         private static void ThrowIfError(uint result)


### PR DESCRIPTION
### What's the problem?

SSPI wrapper doesn't let you query the session key.

- [ ] Bugfix
- [X] New Feature

### What's the solution?

Expose the session key.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

N/A
