### PR TITLE
Fixed issue where subsession key was being populated incorrectly

### DIFF
--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -23,9 +23,19 @@ namespace Kerberos.NET.Client
 
         public KrbEncryptionKey AuthenticateServiceResponse(string asRepEncoded)
         {
-            var apRep = KrbApRep.DecodeApplication(Convert.FromBase64String(asRepEncoded));
+            return AuthenticateServiceResponse(Convert.FromBase64String(asRepEncoded));
+        }
 
-            var decrypted = new DecryptedKrbApRep(apRep) { CTime = this.CTime, CuSec = this.CuSec, SequenceNumber = this.SequenceNumber };
+        public KrbEncryptionKey AuthenticateServiceResponse(ReadOnlyMemory<byte> apRepBytes)
+        {
+            var apRep = KrbApRep.DecodeApplication(apRepBytes);
+
+            var decrypted = new DecryptedKrbApRep(apRep)
+            {
+                CTime = this.CTime,
+                CuSec = this.CuSec,
+                SequenceNumber = this.SequenceNumber
+            };
 
             decrypted.Decrypt(this.SessionKey.AsKey());
 

--- a/Kerberos.NET/Configuration/Krb5ConfigDefaults.cs
+++ b/Kerberos.NET/Configuration/Krb5ConfigDefaults.cs
@@ -314,5 +314,12 @@ namespace Kerberos.NET.Configuration
         [DefaultValue(true)]
         [DisplayName("request_pac")]
         public bool RequestPac { get; set; }
+
+        /// <summary>
+        /// Indicates whether the client should request a PAC during AS-REQ. Default is true.
+        /// </summary>
+        [DefaultValue(PrincipalNameType.NT_ENTERPRISE)]
+        [DisplayName("default_name_type")]
+        public PrincipalNameType DefaultNameType { get; set; }
     }
 }

--- a/Kerberos.NET/Entities/Krb/KrbApReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApReq.cs
@@ -63,9 +63,13 @@ namespace Kerberos.NET.Entities
                 CName = tgsRep.CName,
                 Realm = ticket.Realm,
                 SequenceNumber = GetNonce(),
-                Subkey = KrbEncryptionKey.Generate(authenticatorKey.EncryptionType),
                 Checksum = KrbChecksum.EncodeDelegationChecksum(new DelegationInfo(rst))
             };
+
+            if (rst.ApOptions.HasFlag(ApOptions.MutualRequired))
+            {
+                authenticator.Subkey = KrbEncryptionKey.Generate(authenticatorKey.EncryptionType);
+            }
 
             Now(out DateTimeOffset ctime, out int usec);
 

--- a/Kerberos.NET/Entities/Krb/KrbAsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsReq.cs
@@ -141,7 +141,7 @@ namespace Kerberos.NET.Entities
 
             return KrbPrincipalName.FromString(
                 credential.UserName,
-                PrincipalNameType.NT_ENTERPRISE,
+                credential.Configuration.Defaults.DefaultNameType,
                 credential.Domain
             );
         }

--- a/Kerberos.NET/KerberosAuthenticator.cs
+++ b/Kerberos.NET/KerberosAuthenticator.cs
@@ -77,15 +77,6 @@ namespace Kerberos.NET
 
             SetMinimumIdentity(krbApReq, claims);
 
-            string apRep = null;
-
-            if (krbApReq.Options.HasFlag(ApOptions.MutualRequired))
-            {
-                var apRepEncoded = krbApReq.CreateResponseMessage().EncodeApplication();
-
-                apRep = Convert.ToBase64String(apRepEncoded.ToArray());
-            }
-
             return new KerberosIdentity(
                 claims,
                 "Kerberos",
@@ -93,7 +84,7 @@ namespace Kerberos.NET
                 ClaimTypes.Role,
                 restrictions,
                 this.validator.ValidateAfterDecrypt,
-                apRep
+                krbApReq
             );
         }
 

--- a/Kerberos.NET/KerberosIdentity.cs
+++ b/Kerberos.NET/KerberosIdentity.cs
@@ -1,11 +1,13 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 
 namespace Kerberos.NET
@@ -19,18 +21,28 @@ namespace Kerberos.NET
             string roleType,
             IEnumerable<Restriction> restrictions,
             ValidationActions validationMode,
-            string apRep
+            DecryptedKrbApReq krbApReq
         )
             : base(userClaims, authenticationType, nameType, roleType)
         {
             this.Restrictions = restrictions.GroupBy(r => r.Type).ToDictionary(r => r.Key, r => r.ToList().AsEnumerable());
             this.ValidationMode = validationMode;
-            this.ApRep = apRep;
+
+            if (krbApReq.Options.HasFlag(ApOptions.MutualRequired))
+            {
+                var apRepEncoded = krbApReq.CreateResponseMessage().EncodeApplication();
+
+                this.ApRep = Convert.ToBase64String(apRepEncoded.ToArray());
+            }
+
+            this.SessionKey = krbApReq.SessionKey.GetKey();
         }
 
         public IDictionary<AuthorizationDataType, IEnumerable<Restriction>> Restrictions { get; }
 
         public ValidationActions ValidationMode { get; }
+
+        public ReadOnlyMemory<byte> SessionKey { get; }
 
         public string ApRep { get; }
     }

--- a/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
@@ -387,6 +387,43 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public async Task E2E_WithNegotiate_NoMutual()
+        {
+            var port = NextPort();
+
+            using (var listener = StartListener(port))
+            {
+                await RequestAndValidateTickets(
+                    listener,
+                    AdminAtCorpUserName,
+                    FakeAdminAtCorpPassword,
+                    $"127.0.0.1:{port}",
+                    encodeNego: true,
+                    mutualAuth: false
+                );
+            }
+        }
+
+
+        [TestMethod]
+        public async Task E2E_NoMutual()
+        {
+            var port = NextPort();
+
+            using (var listener = StartListener(port))
+            {
+                await RequestAndValidateTickets(
+                    listener,
+                    AdminAtCorpUserName,
+                    FakeAdminAtCorpPassword,
+                    $"127.0.0.1:{port}",
+                    encodeNego: false,
+                    mutualAuth: false
+                );
+            }
+        }
+
+        [TestMethod]
         public async Task E2E_S4U()
         {
             var port = NextPort();

--- a/Tests/Tests.Kerberos.NET/KrbApReq/AuthenticatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/AuthenticatorTests.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -29,7 +29,7 @@ namespace Tests.Kerberos.NET
             "RXlv1dmdYUHwQ3M";
 
         [TestMethod]
-        public async Task AuthenticatorGetsAsRep()
+        public async Task AuthenticatorGetsApRep()
         {
             var authenticator = new KerberosAuthenticator(
                 new KerberosValidator(new KeyTable(ReadDataFile("sample.keytab")))


### PR DESCRIPTION
### What's the problem?

Subsession key was always being populated which was technically incorrect.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Only generate a subsession key when the client asks for it.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

N/A
