### PR TITLE
Added fallback logic to detect if enterprise nametype isn't understood

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -385,6 +385,13 @@ namespace Kerberos.NET.Client
                         continue;
                     }
 
+                    if (pex?.Error?.ErrorCode == KerberosErrorCode.KDC_ERR_C_PRINCIPAL_UNKNOWN &&
+                        credential.PrincipalNameType == PrincipalNameType.NT_ENTERPRISE)
+                    {
+                        credential.PrincipalNameType = PrincipalNameType.NT_PRINCIPAL;
+                        continue;
+                    }
+
                     // in this case we don't know what it was so bail
 
                     this.logger.LogKerberosProtocolException(pex);

--- a/Kerberos.NET/Credentials/KerberosCredential.cs
+++ b/Kerberos.NET/Credentials/KerberosCredential.cs
@@ -32,6 +32,14 @@ namespace Kerberos.NET.Credentials
             set => this.config = value;
         }
 
+        private PrincipalNameType? nameType;
+
+        public PrincipalNameType PrincipalNameType
+        {
+            get => this.nameType ?? this.Configuration.Defaults.DefaultNameType;
+            set => this.nameType = value;
+        }
+
         public virtual void TransformKdcReq(KrbKdcReq req)
         {
             if (req == null)

--- a/Kerberos.NET/Entities/Krb/KrbAsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsReq.cs
@@ -141,7 +141,7 @@ namespace Kerberos.NET.Entities
 
             return KrbPrincipalName.FromString(
                 credential.UserName,
-                credential.Configuration.Defaults.DefaultNameType,
+                credential.PrincipalNameType,
                 credential.Domain
             );
         }

--- a/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
@@ -424,6 +424,24 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public async Task E2E_NameTypeFallback()
+        {
+            var port = NextPort();
+
+            using (var listener = StartListener(port))
+            {
+                await RequestAndValidateTickets(
+                    listener,
+                    AdminFallbackAtCorpUserName,
+                    FakeAdminAtCorpPassword,
+                    $"127.0.0.1:{port}",
+                    encodeNego: false,
+                    mutualAuth: false
+                );
+            }
+        }
+
+        [TestMethod]
         public async Task E2E_S4U()
         {
             var port = NextPort();

--- a/Tests/Tests.Kerberos.NET/End2End/KdcListenerTestBase.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/KdcListenerTestBase.cs
@@ -24,6 +24,7 @@ namespace Tests.Kerberos.NET
     public abstract class KdcListenerTestBase : BaseTest
     {
         protected const string AdminAtCorpUserName = "administrator@corp.identityintervention.com";
+        protected const string AdminFallbackAtCorpUserName = "administrator-fallback@corp.identityintervention.com";
         protected const string TestAtCorpUserName = "testuser@corp.identityintervention.com";
         protected const string FakeAdminAtCorpPassword = "P@ssw0rd!";
         protected const string FakeAppServiceSpn = "host/appservice.corp.identityintervention.com";
@@ -146,6 +147,15 @@ namespace Tests.Kerberos.NET
                 );
 
                 await ValidateTicket(ticket, includePac: includePac, spn: spn, mutualAuth: mutualAuth);
+            }
+
+            if (user.Contains("-fallback"))
+            {
+                Assert.AreEqual(PrincipalNameType.NT_PRINCIPAL, kerbCred.PrincipalNameType);
+            }
+            else
+            {
+                Assert.AreEqual(PrincipalNameType.NT_ENTERPRISE, kerbCred.PrincipalNameType);
             }
         }
 

--- a/Tests/Tests.Kerberos.NET/FakePrincipalService.cs
+++ b/Tests/Tests.Kerberos.NET/FakePrincipalService.cs
@@ -32,9 +32,19 @@ namespace Tests.Kerberos.NET
         {
             IKerberosPrincipal principal = null;
 
-            if (principalName.FullyQualifiedName.EndsWith(this.realm, StringComparison.InvariantCultureIgnoreCase) ||
+            bool fallback = false;
+
+            if (principalName.FullyQualifiedName.Contains("-fallback", StringComparison.OrdinalIgnoreCase) &&
+                principalName.Type == PrincipalNameType.NT_ENTERPRISE)
+            {
+                principal = null;
+                fallback = true;
+            }
+
+            if ((principalName.FullyQualifiedName.EndsWith(this.realm, StringComparison.InvariantCultureIgnoreCase) ||
                 principalName.FullyQualifiedName.StartsWith("krbtgt", StringComparison.InvariantCultureIgnoreCase) ||
                 principalName.Type == PrincipalNameType.NT_PRINCIPAL)
+                && !fallback)
             {
                 principal = new FakeKerberosPrincipal(principalName.FullyQualifiedName);
             }


### PR DESCRIPTION
### What's the problem?

NT_ENTERPRISE isn't supported by all KDC types.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Try to detect the failure and if so fall back to NT_PRINCIPAL.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Issue #270 
