### PR TITLE
Added ability provicde application-specific checksum and fixed name type from cache

### DIFF
--- a/Bruce/CommandLine/KerberosDumpCommand.cs
+++ b/Bruce/CommandLine/KerberosDumpCommand.cs
@@ -23,6 +23,10 @@ namespace Kerberos.NET.CommandLine
         {
         }
 
+
+        [CommandLineParameter("ticket", Description = "Ticket")]
+        public string Ticket { get; set; }
+
         public override Task<bool> Execute()
         {
             if (!OSPlatform.IsWindows)
@@ -30,7 +34,11 @@ namespace Kerberos.NET.CommandLine
                 return Task.FromResult(false);
             }
 
-            using (var form = new Form1())
+            using (var form = new Form1()
+            {
+                Ticket = this.Ticket,
+                Persistent = string.IsNullOrWhiteSpace(this.Ticket)
+            })
             {
                 Application.Run(form);
             }

--- a/Kerberos.NET/Client/Krb5CredentialCache.cs
+++ b/Kerberos.NET/Client/Krb5CredentialCache.cs
@@ -218,7 +218,7 @@ namespace Kerberos.NET.Client
                 KdcResponse = new KrbTgsRep
                 {
                     Ticket = KrbTicket.DecodeApplication(cred.Ticket),
-                    CName = KrbPrincipalName.FromString(cred.Client.FullyQualifiedName),
+                    CName = KrbPrincipalName.FromString(cred.Client.FullyQualifiedName, cred.Client.Type),
                     CRealm = cred.Client.Realm,
                     EncPart = new KrbEncryptedData { }
                 },

--- a/Kerberos.NET/Entities/RequestServiceTicket.cs
+++ b/Kerberos.NET/Entities/RequestServiceTicket.cs
@@ -71,6 +71,22 @@ namespace Kerberos.NET
         public Krb5Config Configuration { get; set; }
 
         /// <summary>
+        /// Indicates whether the AP-REQ should include a sequence number.
+        /// Default behavior is to include the sequece number.
+        /// </summary>
+        public bool? IncludeSequenceNumber { get; set; }
+
+        /// <summary>
+        /// Optionally provide the application value over which to generate an authenticator checksum.
+        /// </summary>
+        public ReadOnlyMemory<byte> AuthenticatorChecksumSource { get; set; }
+
+        /// <summary>
+        /// Optionally provide an application checksum for the checksum.
+        /// </summary>
+        public KrbChecksum AuthenticatorChecksum { get; set; }
+
+        /// <summary>
         /// Indicates whether the client should cache the ticket. Default null indicates the client should decide.
         /// </summary>
         public bool? CacheTicket { get; set; }

--- a/Samples/KerbDump/Form1.Designer.cs
+++ b/Samples/KerbDump/Form1.Designer.cs
@@ -46,6 +46,7 @@
             this.btnClear = new System.Windows.Forms.Button();
             this.btnRequest = new System.Windows.Forms.Button();
             this.btnExport = new System.Windows.Forms.Button();
+            this.lblDecode = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -55,10 +56,10 @@
             // button1
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.button1.Location = new System.Drawing.Point(1435, 580);
-            this.button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.button1.Location = new System.Drawing.Point(1640, 773);
+            this.button1.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(152, 27);
+            this.button1.Size = new System.Drawing.Size(174, 36);
             this.button1.TabIndex = 1;
             this.button1.Text = "Decode";
             this.button1.UseVisualStyleBackColor = true;
@@ -69,8 +70,8 @@
             this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer1.Location = new System.Drawing.Point(1, 14);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.splitContainer1.Location = new System.Drawing.Point(1, 19);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -88,9 +89,9 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.treeView1);
-            this.splitContainer1.Size = new System.Drawing.Size(1600, 526);
-            this.splitContainer1.SplitterDistance = 282;
-            this.splitContainer1.SplitterWidth = 5;
+            this.splitContainer1.Size = new System.Drawing.Size(1829, 701);
+            this.splitContainer1.SplitterDistance = 322;
+            this.splitContainer1.SplitterWidth = 6;
             this.splitContainer1.TabIndex = 2;
             // 
             // label2
@@ -98,10 +99,10 @@
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 317);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(5, 423);
+            this.label2.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(53, 15);
+            this.label2.Size = new System.Drawing.Size(68, 20);
             this.label2.TabIndex = 9;
             this.label2.Text = "Key Type";
             // 
@@ -113,9 +114,10 @@
             this.ddlKeyType.Items.AddRange(new object[] {
             "Password",
             "Kerberos Key"});
-            this.ddlKeyType.Location = new System.Drawing.Point(4, 338);
+            this.ddlKeyType.Location = new System.Drawing.Point(5, 451);
+            this.ddlKeyType.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.ddlKeyType.Name = "ddlKeyType";
-            this.ddlKeyType.Size = new System.Drawing.Size(275, 23);
+            this.ddlKeyType.Size = new System.Drawing.Size(314, 28);
             this.ddlKeyType.TabIndex = 8;
             this.ddlKeyType.SelectedIndexChanged += new System.EventHandler(this.ddlKeyType_SelectedIndexChanged);
             // 
@@ -126,10 +128,10 @@
             this.chkRemember.AutoSize = true;
             this.chkRemember.Checked = true;
             this.chkRemember.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkRemember.Location = new System.Drawing.Point(4, 499);
-            this.chkRemember.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkRemember.Location = new System.Drawing.Point(5, 667);
+            this.chkRemember.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.chkRemember.Name = "chkRemember";
-            this.chkRemember.Size = new System.Drawing.Size(84, 19);
+            this.chkRemember.Size = new System.Drawing.Size(104, 24);
             this.chkRemember.TabIndex = 7;
             this.chkRemember.Text = "Remember";
             this.chkRemember.UseVisualStyleBackColor = true;
@@ -139,10 +141,10 @@
             this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(4, 446);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(5, 595);
+            this.label4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(32, 15);
+            this.label4.Size = new System.Drawing.Size(40, 20);
             this.label4.TabIndex = 6;
             this.label4.Text = "Host";
             // 
@@ -150,21 +152,21 @@
             // 
             this.txtHost.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtHost.Location = new System.Drawing.Point(4, 465);
-            this.txtHost.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.txtHost.Location = new System.Drawing.Point(5, 620);
+            this.txtHost.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.txtHost.Name = "txtHost";
             this.txtHost.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtHost.Size = new System.Drawing.Size(274, 23);
+            this.txtHost.Size = new System.Drawing.Size(313, 27);
             this.txtHost.TabIndex = 5;
             // 
             // chkEncodedKey
             // 
             this.chkEncodedKey.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.chkEncodedKey.AutoSize = true;
-            this.chkEncodedKey.Location = new System.Drawing.Point(142, 499);
-            this.chkEncodedKey.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkEncodedKey.Location = new System.Drawing.Point(150, 667);
+            this.chkEncodedKey.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.chkEncodedKey.Name = "chkEncodedKey";
-            this.chkEncodedKey.Size = new System.Drawing.Size(136, 19);
+            this.chkEncodedKey.Size = new System.Drawing.Size(168, 24);
             this.chkEncodedKey.TabIndex = 4;
             this.chkEncodedKey.Text = "Password is Encoded";
             this.chkEncodedKey.UseVisualStyleBackColor = true;
@@ -173,21 +175,21 @@
             // 
             this.txtKey.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtKey.Location = new System.Drawing.Point(4, 368);
-            this.txtKey.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.txtKey.Location = new System.Drawing.Point(5, 491);
+            this.txtKey.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.txtKey.Multiline = true;
             this.txtKey.Name = "txtKey";
             this.txtKey.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtKey.Size = new System.Drawing.Size(275, 69);
+            this.txtKey.Size = new System.Drawing.Size(314, 91);
             this.txtKey.TabIndex = 2;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 1);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(5, 1);
+            this.label1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(102, 15);
+            this.label1.Size = new System.Drawing.Size(129, 20);
             this.label1.TabIndex = 1;
             this.label1.Text = "Encoded Message";
             // 
@@ -196,12 +198,12 @@
             this.txtTicket.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtTicket.Location = new System.Drawing.Point(4, 24);
-            this.txtTicket.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.txtTicket.Location = new System.Drawing.Point(5, 32);
+            this.txtTicket.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.txtTicket.Multiline = true;
             this.txtTicket.Name = "txtTicket";
             this.txtTicket.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtTicket.Size = new System.Drawing.Size(274, 287);
+            this.txtTicket.Size = new System.Drawing.Size(313, 381);
             this.txtTicket.TabIndex = 0;
             // 
             // treeView1
@@ -210,18 +212,18 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.treeView1.Location = new System.Drawing.Point(0, 0);
-            this.treeView1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.treeView1.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.treeView1.Name = "treeView1";
-            this.treeView1.Size = new System.Drawing.Size(1307, 523);
+            this.treeView1.Size = new System.Drawing.Size(1484, 696);
             this.treeView1.TabIndex = 3;
             // 
             // btnDecodeLocal
             // 
             this.btnDecodeLocal.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnDecodeLocal.Location = new System.Drawing.Point(1162, 580);
-            this.btnDecodeLocal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnDecodeLocal.Location = new System.Drawing.Point(1328, 773);
+            this.btnDecodeLocal.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnDecodeLocal.Name = "btnDecodeLocal";
-            this.btnDecodeLocal.Size = new System.Drawing.Size(266, 27);
+            this.btnDecodeLocal.Size = new System.Drawing.Size(304, 36);
             this.btnDecodeLocal.TabIndex = 3;
             this.btnDecodeLocal.Text = "Decode with LSA Secret";
             this.btnDecodeLocal.UseVisualStyleBackColor = true;
@@ -230,10 +232,10 @@
             // btnLoadKeytab
             // 
             this.btnLoadKeytab.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnLoadKeytab.Location = new System.Drawing.Point(14, 580);
-            this.btnLoadKeytab.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnLoadKeytab.Location = new System.Drawing.Point(16, 773);
+            this.btnLoadKeytab.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnLoadKeytab.Name = "btnLoadKeytab";
-            this.btnLoadKeytab.Size = new System.Drawing.Size(124, 27);
+            this.btnLoadKeytab.Size = new System.Drawing.Size(142, 36);
             this.btnLoadKeytab.TabIndex = 4;
             this.btnLoadKeytab.Text = "Load Keytab";
             this.btnLoadKeytab.UseVisualStyleBackColor = true;
@@ -243,19 +245,20 @@
             // 
             this.lblKeytab.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblKeytab.AutoSize = true;
-            this.lblKeytab.Location = new System.Drawing.Point(145, 586);
-            this.lblKeytab.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblKeytab.Location = new System.Drawing.Point(166, 781);
+            this.lblKeytab.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.lblKeytab.Name = "lblKeytab";
-            this.lblKeytab.Size = new System.Drawing.Size(0, 15);
+            this.lblKeytab.Size = new System.Drawing.Size(64, 20);
             this.lblKeytab.TabIndex = 5;
+            this.lblKeytab.Text = "Keytab...";
             // 
             // btnClear
             // 
             this.btnClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClear.Location = new System.Drawing.Point(792, 580);
-            this.btnClear.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnClear.Location = new System.Drawing.Point(905, 773);
+            this.btnClear.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnClear.Name = "btnClear";
-            this.btnClear.Size = new System.Drawing.Size(120, 27);
+            this.btnClear.Size = new System.Drawing.Size(137, 36);
             this.btnClear.TabIndex = 6;
             this.btnClear.Text = "Clear";
             this.btnClear.UseVisualStyleBackColor = true;
@@ -264,10 +267,10 @@
             // btnRequest
             // 
             this.btnRequest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnRequest.Location = new System.Drawing.Point(919, 580);
-            this.btnRequest.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnRequest.Location = new System.Drawing.Point(1050, 773);
+            this.btnRequest.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnRequest.Name = "btnRequest";
-            this.btnRequest.Size = new System.Drawing.Size(236, 27);
+            this.btnRequest.Size = new System.Drawing.Size(270, 36);
             this.btnRequest.TabIndex = 7;
             this.btnRequest.Text = "Request for";
             this.btnRequest.UseVisualStyleBackColor = true;
@@ -276,19 +279,31 @@
             // btnExport
             // 
             this.btnExport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnExport.Location = new System.Drawing.Point(1435, 547);
-            this.btnExport.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnExport.Location = new System.Drawing.Point(1640, 729);
+            this.btnExport.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnExport.Name = "btnExport";
-            this.btnExport.Size = new System.Drawing.Size(152, 27);
+            this.btnExport.Size = new System.Drawing.Size(174, 36);
             this.btnExport.TabIndex = 8;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             // 
+            // lblDecode
+            // 
+            this.lblDecode.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblDecode.AutoSize = true;
+            this.lblDecode.Location = new System.Drawing.Point(16, 737);
+            this.lblDecode.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.lblDecode.Name = "lblDecode";
+            this.lblDecode.Size = new System.Drawing.Size(83, 20);
+            this.lblDecode.TabIndex = 10;
+            this.lblDecode.Text = "Decoding...";
+            // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1601, 621);
+            this.ClientSize = new System.Drawing.Size(1830, 828);
+            this.Controls.Add(this.lblDecode);
             this.Controls.Add(this.btnExport);
             this.Controls.Add(this.btnRequest);
             this.Controls.Add(this.btnClear);
@@ -297,9 +312,11 @@
             this.Controls.Add(this.btnDecodeLocal);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.button1);
-            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.Name = "Form1";
             this.Text = "Decode Kerberos Message";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
+            this.Load += new System.EventHandler(this.Form1_Load);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
@@ -329,6 +346,7 @@
         private System.Windows.Forms.ComboBox ddlKeyType;
         private System.Windows.Forms.TreeView treeView1;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblDecode;
     }
 }
 


### PR DESCRIPTION
### What's the problem?

Not all application protocols expect the GSS checksum information to be present in the authenticator so allow users to bring their own.

Also fixes a bug where the cache was always using the NT_ENTERPRISE name type when it should be using whatever it was told by the KDC.

- [X] Bugfix
- [X] New Feature

### What's the solution?

Allow users to bring their own checksum if necessary.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?
N/A