### PR TITLE
Don't use expired tickets if you can help it

### DIFF
--- a/Bruce/CommandLine/KerberosListCommand.cs
+++ b/Bruce/CommandLine/KerberosListCommand.cs
@@ -199,7 +199,7 @@ namespace Kerberos.NET.CommandLine
 
             var ticketCache = new Krb5TicketCache(path);
 
-            var tickets = ticketCache.Krb5Cache.Credentials.ToArray();
+            var tickets = ticketCache.Krb5Cache.Credentials.Where(c => c.EndTime >= DateTimeOffset.UtcNow).ToArray();
 
             this.WriteLine(string.Format("{0}: {{TicketCount}}", SR.Resource("CommandLine_KList_Count")), tickets.Length);
             this.WriteLine();
@@ -233,7 +233,7 @@ namespace Kerberos.NET.CommandLine
 
                     if (first)
                     {
-                        key = ticketEntryNumber + key.Substring(ticketEntryNumber.Length);
+                        key = ticketEntryNumber + key[ticketEntryNumber.Length..];
 
                         first = false;
                     }

--- a/Kerberos.NET/Client/KerberosClientCacheEntry.cs
+++ b/Kerberos.NET/Client/KerberosClientCacheEntry.cs
@@ -20,6 +20,21 @@ namespace Kerberos.NET.Client
 
         public TicketFlags Flags { get; set; }
 
+        public DateTimeOffset AuthTime { get; set; }
+
+        public DateTimeOffset? StartTime { get; set; }
+
+        public DateTimeOffset EndTime { get; set; }
+
+        public DateTimeOffset? RenewTill { get; set; }
+
+        public bool IsValid(bool ignoreExpiration = false)
+        {
+            return this.KdcResponse != null &&
+                  (ignoreExpiration || (this.StartTime <= DateTimeOffset.UtcNow &&
+                                        this.EndTime >= DateTimeOffset.UtcNow));
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is KerberosClientCacheEntry entry)
@@ -52,12 +67,40 @@ namespace Kerberos.NET.Client
                 return false;
             }
 
+            if (other.AuthTime != this.AuthTime)
+            {
+                return false;
+            }
+
+            if (other.StartTime != this.StartTime)
+            {
+                return false;
+            }
+
+            if (other.EndTime != this.EndTime)
+            {
+                return false;
+            }
+
+            if (other.RenewTill != this.RenewTill)
+            {
+                return false;
+            }
+
             return true;
         }
 
         public override int GetHashCode()
         {
-            return EntityHashCode.GetHashCode(this.KdcResponse, this.SessionKey, this.Nonce);
+            return EntityHashCode.GetHashCode(
+                this.KdcResponse,
+                this.SessionKey,
+                this.Nonce,
+                this.AuthTime,
+                this.StartTime,
+                this.EndTime,
+                this.RenewTill
+            );
         }
 
         public static bool operator ==(KerberosClientCacheEntry left, KerberosClientCacheEntry right)

--- a/Kerberos.NET/Client/Krb5CredentialCache.cs
+++ b/Kerberos.NET/Client/Krb5CredentialCache.cs
@@ -228,7 +228,11 @@ namespace Kerberos.NET.Client
                     KeyValue = cred.KeyBlock.Value
                 },
                 Flags = cred.Flags,
-                SName = KrbPrincipalName.FromString(cred.Server.FullyQualifiedName)
+                SName = KrbPrincipalName.FromString(cred.Server.FullyQualifiedName),
+                AuthTime = cred.AuthTime,
+                StartTime = cred.StartTime,
+                EndTime = cred.EndTime,
+                RenewTill = cred.RenewTill <= DateTimeOffset.MinValue ? null : cred.RenewTill
             };
         }
 

--- a/Kerberos.NET/Entities/RequestServiceTicket.cs
+++ b/Kerberos.NET/Entities/RequestServiceTicket.cs
@@ -87,6 +87,11 @@ namespace Kerberos.NET
         public KrbChecksum AuthenticatorChecksum { get; set; }
 
         /// <summary>
+        /// Indicates whether the client should attempt to use tickets that are already expired.
+        /// </summary>
+        public bool CanRetrieveExpiredTickets { get; set; }
+
+        /// <summary>
         /// Indicates whether the client should cache the ticket. Default null indicates the client should decide.
         /// </summary>
         public bool? CacheTicket { get; set; }

--- a/Samples/KerbDumpCore/MessageTreeView.cs
+++ b/Samples/KerbDumpCore/MessageTreeView.cs
@@ -331,7 +331,12 @@ namespace KerbDump
             {
                 Reflect.IsBytes(value, out ReadOnlyMemory<byte> mem);
 
+                writer.WriteStartObject();
+                writer.WritePropertyName("Length");
+                writer.WriteValue(mem.Length);
+                writer.WritePropertyName("Value");
                 writer.WriteValue(Convert.ToBase64String(mem.ToArray()));
+                writer.WriteEndObject();
             }
         }
 

--- a/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
+++ b/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
@@ -3,15 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Kerberos.NET;
 using Kerberos.NET.Client;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Tests.Kerberos.NET
 {
@@ -127,12 +127,31 @@ namespace Tests.Kerberos.NET
         {
             using (var client = new KerberosClient() { Cache = new Krb5TicketCache(FilePath) })
             {
-                var apReq = await client.GetServiceTicket("krbtgt/IPA.IDENTITYINTERVENTION.COM");
+                var rep = await client.GetServiceTicket(new RequestServiceTicket
+                {
+                    ServicePrincipalName = "krbtgt/IPA.IDENTITYINTERVENTION.COM",
+                    CanRetrieveExpiredTickets = true
+                });
+
+                var apReq = rep.ApReq;
 
                 Assert.IsNotNull(apReq);
                 Assert.IsNotNull(apReq.Authenticator);
                 Assert.IsNotNull(apReq.Ticket);
                 Assert.AreEqual("krbtgt@IPA.IDENTITYINTERVENTION.COM", apReq.Ticket.SName.FullyQualifiedName);
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(AggregateException))]
+        public async Task ClientCannotGetExpiredCachedItem()
+        {
+            using (var client = new KerberosClient() { Cache = new Krb5TicketCache(FilePath) })
+            {
+                await client.GetServiceTicket(new RequestServiceTicket
+                {
+                    ServicePrincipalName = "krbtgt/IPA.IDENTITYINTERVENTION.COM"
+                });
             }
         }
     }


### PR DESCRIPTION
### What's the problem?

Client currently just uses whatever ticket is in the cache if it finds a matching one and relies on the server to tell us it's not valid.

- [ ] Bugfix
- [X] New Feature

### What's the solution?

Check that the ticket is expired before using it.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

N/A
