### PR TITLE
Bugfix/tgt flags carry

### DIFF
--- a/Bruce/CommandLine/KerberosInitCommand.cs
+++ b/Bruce/CommandLine/KerberosInitCommand.cs
@@ -219,6 +219,7 @@ namespace Kerberos.NET.CommandLine
             SetClientProperty(this.Renew, client, AuthenticationOptions.Renew);
             SetClientProperty(this.Renewable, client, AuthenticationOptions.Renewable);
             SetClientProperty(this.Canonicalize, client, AuthenticationOptions.Canonicalize);
+            SetClientProperty(this.Forward, client, AuthenticationOptions.Forwardable);
 
             if (this.RenewLifetime.HasValue)
             {

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -1040,7 +1040,7 @@ namespace Kerberos.NET.Client
                 new RequestServiceTicket
                 {
                     ServicePrincipalName = spn,
-                    KdcOptions = this.KdcOptions | KdcOptions.Renew | KdcOptions.RenewableOk,
+                    KdcOptions = ReconcileKdcFlags(this.KdcOptions, entry.Flags) | KdcOptions.Renew | KdcOptions.RenewableOk,
                     Realm = ResolveKdcTarget(entry)
                 },
                 entry.SessionKey,

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -567,6 +567,7 @@ namespace Kerberos.NET.Client
                         var tgtEntry = this.CopyTicket(tgtCacheName);
 
                         rst.Realm = ResolveKdcTarget(tgtEntry);
+                        rst.KdcOptions = ReconcileKdcFlags(rst.KdcOptions, tgtEntry.Flags);
 
                         serviceTicketCacheEntry = await this.RequestTgs(rst, tgtEntry, cancellation).ConfigureAwait(false);
 
@@ -684,6 +685,28 @@ namespace Kerberos.NET.Client
                     CuSec = authenticator.CuSec,
                     SequenceNumber = authenticator.SequenceNumber
                 };
+            }
+        }
+
+        private static KdcOptions ReconcileKdcFlags(KdcOptions options, TicketFlags ticketFlags)
+        {
+            SetKdcOptionsFlag(ticketFlags, TicketFlags.Forwardable, KdcOptions.Forwardable, ref options);
+            SetKdcOptionsFlag(ticketFlags, TicketFlags.Forwarded, KdcOptions.Forwarded, ref options);
+            SetKdcOptionsFlag(ticketFlags, TicketFlags.Renewable, KdcOptions.Renewable, ref options);
+
+            return options;
+        }
+
+        private static void SetKdcOptionsFlag(
+            TicketFlags ticketFlags,
+            TicketFlags ticketFlag,
+            KdcOptions kdcFlag,
+            ref KdcOptions options
+        )
+        {
+            if ((ticketFlags & ticketFlag) == 0)
+            {
+                options &= ~kdcFlag;
             }
         }
 

--- a/Kerberos.NET/Entities/Pac/PrivilegedAttributeCertificate.cs
+++ b/Kerberos.NET/Entities/Pac/PrivilegedAttributeCertificate.cs
@@ -126,6 +126,7 @@ namespace Kerberos.NET.Entities
 
             if (!KnownTypes.TryGetValue(type, out Type pacObjectType))
             {
+                this.Attributes[type] = new UnknownPacObject(type, pacInfoBuffer);
                 return;
             }
 

--- a/Kerberos.NET/Ndr/PacObject.cs
+++ b/Kerberos.NET/Ndr/PacObject.cs
@@ -7,6 +7,29 @@ using System;
 
 namespace Kerberos.NET.Entities.Pac
 {
+    internal sealed class UnknownPacObject : PacObject
+    {
+        public UnknownPacObject(PacType type, ReadOnlyMemory<byte> blob)
+        {
+            this.PacType = type;
+            this.Blob = blob;
+        }
+
+        public override PacType PacType { get; }
+
+        public ReadOnlyMemory<byte> Blob { get; private set; }
+
+        public override ReadOnlyMemory<byte> Marshal()
+        {
+            return this.Blob;
+        }
+
+        public override void Unmarshal(ReadOnlyMemory<byte> bytes)
+        {
+            this.Blob = bytes;
+        }
+    }
+
     public abstract class PacObject // not NDR thing
     {
         public abstract PacType PacType { get; }

--- a/Tests/Tests.Kerberos.NET/Crypto/BaseCryptoTest.cs
+++ b/Tests/Tests.Kerberos.NET/Crypto/BaseCryptoTest.cs
@@ -12,9 +12,9 @@ namespace Tests.Kerberos.NET
 {
     public class BaseCryptoTest
     {
-        protected static byte[] HexToByte(string hex)
+        public static byte[] HexToByte(string hex)
         {
-            hex = hex?.Replace(" ", string.Empty).Replace("0x", string.Empty).Replace(",", string.Empty);
+            hex = hex?.Replace(" ", string.Empty).Replace(Environment.NewLine, string.Empty).Replace("0x", string.Empty).Replace(",", string.Empty).Trim();
 
             return Enumerable.Range(0, hex.Length)
                      .Where(x => x % 2 == 0)


### PR DESCRIPTION
### What's the problem?

Forwardable and related flags shouldn't be included on requests if the TGT doesn't have one.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Remove default flags if TGT doesn't contain them.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

N/A
