### PR TITLE
Cleaned up S4U handling and fixed weird session key issue with caching

### DIFF
--- a/Bruce/CommandLine/KerberosConstrainedDelegationCommand.cs
+++ b/Bruce/CommandLine/KerberosConstrainedDelegationCommand.cs
@@ -1,0 +1,115 @@
+﻿using Kerberos.NET.Client;
+using Kerberos.NET.Credentials;
+using Kerberos.NET.Crypto;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kerberos.NET.CommandLine.CommandLine
+{
+    [CommandLineCommand("kcd", Description = "KerberosConstrainedDelegation")]
+    public class KerberosConstrainedDelegationCommand : BaseCommand
+    {
+        public KerberosConstrainedDelegationCommand(CommandLineParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        [CommandLineParameter("principal",
+            FormalParameter = true,
+            Required = true,
+            Description = "UserPrincipalName")]
+        public override string PrincipalName { get; set; }
+
+        [CommandLineParameter("realm", Description = "Realm")]
+        public override string Realm { get; set; }
+
+        [CommandLineParameter("verbose", Description = "Verbose")]
+        public override bool Verbose { get; set; }
+
+        [CommandLineParameter("spn", Description = "ServicePrincipalName")]
+        public string ServicePrincipalName { get; set; }
+
+        [CommandLineParameter("spn-pass", Description = "ServicePrincipalNamePassword")]
+        public string ServicePrincipalNamePassword { get; set; }
+
+        [CommandLineParameter("sam", Description = "SamAccountName")]
+        public string SamAccountName { get; set; }
+
+        [CommandLineParameter("delegated", Description = "Delegated")]
+        public string Delegated { get; set; }
+
+        public override async Task<bool> Execute()
+        {
+            if (await base.Execute())
+            {
+                return true;
+            }
+
+            this.WriteLine();
+
+            var client = this.CreateClient(verbose: this.Verbose);
+
+            this.WriteLine(3, "Double Hop: {Client} => {MiddleBox} => {Backend}", client.UserPrincipalName, this.ServicePrincipalName, this.Delegated);
+            this.WriteLine();
+
+            var serviceTicket = await client.GetServiceTicket(new RequestServiceTicket { ServicePrincipalName = this.ServicePrincipalName });
+
+            this.WriteHeader("======== Client ========");
+            this.WriteLine();
+
+            this.WriteLine(3, "{User} @ {Realm} => {Spn}", client.UserPrincipalName, client.DefaultDomain, serviceTicket.ApReq.Ticket.SName.FullyQualifiedName);
+            this.WriteLine();
+
+            this.WriteHeader("======== Middle box ========");
+
+            var serviceCred = new KerberosPasswordCredential(this.SamAccountName, this.ServicePrincipalNamePassword, serviceTicket.ApReq.Ticket.Realm);
+
+            var ping = await KerberosPing.Ping(serviceCred, client);
+
+            serviceCred.IncludePreAuthenticationHints(ping.Error.DecodePreAuthentication());
+
+            var keytab = new KeyTable(serviceCred.CreateKey());
+
+            var authenticator = new KerberosAuthenticator(this.SamAccountName, keytab, client.Configuration);
+
+            var identity = await authenticator.Authenticate(serviceTicket.ApReq.EncodeGssApi()) as KerberosIdentity;
+
+            var whoami = this.CreateCommand<KerberosWhoAmI>();
+            whoami.All = true;
+            whoami.DescribeTicket(identity);
+
+            this.WriteLine();
+
+            this.WriteHeader("======== Backend ========");
+
+            var delegated = await identity.GetDelegatedServiceTicket(this.Delegated);
+
+            this.DescribeApReq(delegated);
+
+            return true;
+        }
+
+        private void DescribeApReq(ApplicationSessionContext delegated)
+        {
+            var properties = new List<(string, object)>()
+            { };
+
+            GetObjectProperties(
+                new object[]
+                {
+                    delegated,
+                    delegated.ApReq,
+                    delegated.ApReq.Ticket,
+                    delegated.ApReq.Ticket.SName,
+                    delegated.ApReq.Ticket.EncryptedPart,
+                    delegated.ApReq.Authenticator,
+                    delegated.SessionKey
+                },
+            properties
+            );
+
+            this.WriteProperties(properties);
+        }
+    }
+}

--- a/Bruce/CommandLine/KerberosPing.cs
+++ b/Bruce/CommandLine/KerberosPing.cs
@@ -1,0 +1,58 @@
+﻿using Kerberos.NET.Client;
+using Kerberos.NET.Credentials;
+using Kerberos.NET.Entities;
+using Kerberos.NET.Transport;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Kerberos.NET.CommandLine
+{
+    internal class PingResult
+    {
+        public KrbAsReq AsReq { get; set; }
+
+        public KrbAsRep AsRep { get; set; }
+
+        public KrbError Error { get; set; }
+    }
+
+    internal static class KerberosPing
+    {
+        public static async Task<PingResult> Ping(KerberosCredential credential, KerberosClient client, ILoggerFactory logger = null)
+        {
+            credential.Configuration = client.Configuration;
+
+            var asReqMessage = KrbAsReq.CreateAsReq(credential, AuthenticationOptions.Renewable);
+
+            var asReq = asReqMessage.EncodeApplication();
+
+            var transport = new KerberosTransportSelector(
+                new IKerberosTransport[]
+                {
+                    new TcpKerberosTransport(logger),
+                    new UdpKerberosTransport(logger),
+                    new HttpsKerberosTransport(logger)
+                },
+                client.Configuration,
+                logger
+            )
+            {
+                ConnectTimeout = TimeSpan.FromSeconds(5)
+            };
+
+            var result = new PingResult { AsReq = asReqMessage };
+
+            try
+            {
+                result.AsRep = await transport.SendMessage<KrbAsRep>(credential.Domain, asReq);
+            }
+            catch (KerberosProtocolException pex)
+            {
+                result.Error = pex.Error;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Bruce/CommandLine/KerberosWhoAmICommand.cs
+++ b/Bruce/CommandLine/KerberosWhoAmICommand.cs
@@ -106,18 +106,7 @@ namespace Kerberos.NET.CommandLine
             }
         }
 
-        private readonly HashSet<string> IgnoredProperties = new HashSet<string>
-        {
-            "PacType",
-            "Reserved3",
-            "NameLength",
-            "UpnLength",
-            "UpnOffset",
-            "DnsDomainNameLength",
-            "DnsDomainNameOffset",
-        };
-
-        private void DescribeTicket(KerberosIdentity identity)
+        internal void DescribeTicket(KerberosIdentity identity)
         {
             this.WriteLine();
 
@@ -141,34 +130,7 @@ namespace Kerberos.NET.CommandLine
                     pac.CredentialType
                 };
 
-                foreach (var obj in objects)
-                {
-                    if (obj == null)
-                    {
-                        continue;
-                    }
-
-                    properties.Add((null, obj.GetType().Name.Humanize(LetterCasing.Title)));
-
-                    var props = obj.GetType().GetProperties();
-
-                    foreach (var prop in props)
-                    {
-                        if (!Reflect.IsEnumerable(prop.PropertyType) &&
-                            prop.PropertyType != typeof(RpcSid) &&
-                            !this.IgnoredProperties.Contains(prop.Name))
-                        {
-                            object value = prop.GetValue(obj);
-
-                            if (value is RpcFileTime ft)
-                            {
-                                value = (DateTimeOffset)ft;
-                            }
-
-                            properties.Add((prop.Name.Humanize(LetterCasing.Title), value));
-                        }
-                    }
-                }
+                GetObjectProperties(objects, properties);
             }
 
             if (this.All || this.Claims)

--- a/Kerberos.NET/Client/Krb5CredentialCache.cs
+++ b/Kerberos.NET/Client/Krb5CredentialCache.cs
@@ -167,26 +167,15 @@ namespace Kerberos.NET.Client
 
             if (entry.Value is KerberosClientCacheEntry entryValue)
             {
-                KrbEncryptionKey sessionKey;
-
-                if (entryValue.KdcResponse is KrbAsRep asRep)
+                if (entryValue.KdcResponse is KrbAsRep asRep && !this.Credentials.Any())
                 {
-                    sessionKey = entryValue.SessionKey;
-
-                    if (!this.Credentials.Any())
-                    {
-                        this.DefaultPrincipalName = FromResponse(asRep, asRep.CName);
-                    }
-                }
-                else
-                {
-                    sessionKey = entryValue.SessionKey;
+                    this.DefaultPrincipalName = FromResponse(asRep, asRep.CName);
                 }
 
                 this.Credentials.Add(new Krb5Credential
                 {
                     Ticket = entryValue.KdcResponse.Ticket.EncodeApplication(),
-                    KeyBlock = new KeyValuePair<EncryptionType, ReadOnlyMemory<byte>>(sessionKey.EType, sessionKey.KeyValue),
+                    KeyBlock = new KeyValuePair<EncryptionType, ReadOnlyMemory<byte>>(entryValue.SessionKey.EType, entryValue.SessionKey.KeyValue),
                     Client = FromResponse(entryValue.KdcResponse, entryValue.KdcResponse.CName),
                     Server = FromResponse(entryValue.KdcResponse, entryValue.KdcResponse.Ticket.SName),
                     AuthData = new List<KrbAuthorizationData>(),

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -46,7 +46,7 @@ namespace Kerberos.NET.Crypto
                 this.ValidateTicketSkew(now, this.Skew, ctime);
             }
 
-            if (TimeEquals(this.CTime, this.Response.CTime))
+            if (!TimeEquals(this.CTime, this.Response.CTime))
             {
                 throw new KerberosValidationException(
                     $"CTime does not match. Sent: {this.CTime.Ticks}; Received: {this.Response.CTime.Ticks}",

--- a/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
@@ -27,6 +27,8 @@ namespace Kerberos.NET.Crypto
 
         public KrbAuthenticator Authenticator { get; private set; }
 
+        public KrbTicket EncryptedTicket => this.token.Ticket;
+
         public KrbEncTicketPart Ticket { get; private set; }
 
         public KrbEncKrbCredPart DelegationTicket { get; private set; }

--- a/Kerberos.NET/Entities/KerberosConstants.cs
+++ b/Kerberos.NET/Entities/KerberosConstants.cs
@@ -88,7 +88,7 @@ namespace Kerberos.NET.Entities
             var bytes = new byte[4];
             Rng.GetBytes(bytes);
 
-            return BinaryPrimitives.ReadInt32BigEndian(bytes);
+            return BinaryPrimitives.ReadInt32BigEndian(bytes) & 0x7fffffff;
         }
 
         public static bool WithinSkew(DateTimeOffset now, DateTimeOffset ctime, int usec, TimeSpan skew)
@@ -102,8 +102,8 @@ namespace Kerberos.NET.Entities
 
         public static bool TimeEquals(DateTimeOffset left, DateTimeOffset right)
         {
-            var leftUsec = left.Ticks % TickUSec;
-            var rightUsec = right.Ticks % TickUSec;
+            var leftUsec = left.Ticks / (TickUSec * 10);
+            var rightUsec = right.Ticks / (TickUSec * 10);
 
             return leftUsec == rightUsec;
         }
@@ -112,7 +112,7 @@ namespace Kerberos.NET.Entities
         {
             var nowTicks = DateTimeOffset.UtcNow.Ticks;
 
-            usec = (int)nowTicks % TickUSec;
+            usec = (int)(nowTicks % TickUSec);
 
             time = new DateTimeOffset(nowTicks - usec, TimeSpan.Zero);
         }

--- a/Kerberos.NET/Entities/Krb/KrbApReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApReq.cs
@@ -56,12 +56,10 @@ namespace Kerberos.NET.Entities
                 throw new ArgumentNullException(nameof(authenticatorKey));
             }
 
-            var ticket = tgsRep.Ticket;
-
             authenticator = new KrbAuthenticator
             {
                 CName = tgsRep.CName,
-                Realm = ticket.Realm
+                Realm = tgsRep.CRealm
             };
 
             if (rst.AuthenticatorChecksum != null)
@@ -98,7 +96,7 @@ namespace Kerberos.NET.Entities
 
             var apReq = new KrbApReq
             {
-                Ticket = ticket,
+                Ticket = tgsRep.Ticket,
                 ApOptions = rst.ApOptions,
                 Authenticator = KrbEncryptedData.Encrypt(
                     authenticator.EncodeApplication(),

--- a/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates;
 using Kerberos.NET.Asn1;
 using Kerberos.NET.Configuration;
@@ -60,6 +61,11 @@ namespace Kerberos.NET.Entities
             if (rst.KdcOptions.HasFlag(KdcOptions.EncTktInSkey) && rst.UserToUserTicket != null)
             {
                 additionalTickets.Add(rst.UserToUserTicket);
+            }
+
+            if (!string.IsNullOrWhiteSpace(rst.S4uTarget) && rst.S4uTicket != null)
+            {
+                throw new InvalidOperationException(SR.Resource("S4uTargetTicketBothPresent"));
             }
 
             if (!string.IsNullOrWhiteSpace(rst.S4uTarget))

--- a/Kerberos.NET/IS4UProvider.cs
+++ b/Kerberos.NET/IS4UProvider.cs
@@ -1,0 +1,16 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using Kerberos.NET.Client;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kerberos.NET
+{
+    internal interface IS4UProvider
+    {
+        Task<ApplicationSessionContext> GetServiceTicket(RequestServiceTicket rst, CancellationToken cancellation);
+    }
+}

--- a/Kerberos.NET/KerberosIdentity.cs
+++ b/Kerberos.NET/KerberosIdentity.cs
@@ -7,35 +7,54 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Kerberos.NET.Client;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 
 namespace Kerberos.NET
 {
+    internal sealed class KerberosIdentityResult
+    {
+        public IEnumerable<Claim> UserClaims { get; set; }
+
+        public string AuthenticationType { get; set; }
+
+        public string NameType { get; set; }
+
+        public string RoleType { get; set; }
+
+        public IEnumerable<Restriction> Restrictions { get; set; }
+
+        public ValidationActions ValidationMode { get; set; }
+
+        public DecryptedKrbApReq KrbApReq { get; set; }
+
+        public IS4UProvider S4uProvider { get; set; }
+    }
+
     public class KerberosIdentity : ClaimsIdentity
     {
-        internal KerberosIdentity(
-            IEnumerable<Claim> userClaims,
-            string authenticationType,
-            string nameType,
-            string roleType,
-            IEnumerable<Restriction> restrictions,
-            ValidationActions validationMode,
-            DecryptedKrbApReq krbApReq
-        )
-            : base(userClaims, authenticationType, nameType, roleType)
-        {
-            this.Restrictions = restrictions.GroupBy(r => r.Type).ToDictionary(r => r.Key, r => r.ToList().AsEnumerable());
-            this.ValidationMode = validationMode;
+        private readonly IS4UProvider s4uProvider;
+        private readonly DecryptedKrbApReq krbApReq;
 
-            if (krbApReq.Options.HasFlag(ApOptions.MutualRequired))
+        internal KerberosIdentity(KerberosIdentityResult identity)
+            : base(identity.UserClaims, identity.AuthenticationType, identity.NameType, identity.RoleType)
+        {
+            this.Restrictions = identity.Restrictions.GroupBy(r => r.Type).ToDictionary(r => r.Key, r => r.ToList().AsEnumerable());
+            this.ValidationMode = identity.ValidationMode;
+
+            if (identity.KrbApReq.Options.HasFlag(ApOptions.MutualRequired))
             {
-                var apRepEncoded = krbApReq.CreateResponseMessage().EncodeApplication();
+                var apRepEncoded = identity.KrbApReq.CreateResponseMessage().EncodeApplication();
 
                 this.ApRep = Convert.ToBase64String(apRepEncoded.ToArray());
             }
 
-            this.SessionKey = krbApReq.SessionKey.GetKey();
+            this.SessionKey = identity.KrbApReq.SessionKey.GetKey();
+            this.s4uProvider = identity.S4uProvider;
+            this.krbApReq = identity.KrbApReq;
         }
 
         public IDictionary<AuthorizationDataType, IEnumerable<Restriction>> Restrictions { get; }
@@ -45,5 +64,39 @@ namespace Kerberos.NET
         public ReadOnlyMemory<byte> SessionKey { get; }
 
         public string ApRep { get; }
+
+
+        /// <summary>
+        /// Request a service ticket from a KDC using TGS-REQ
+        /// </summary>
+        /// <param name="spn">The SPN of the requested service</param>
+        /// <returns>Returns the requested <see cref="ApplicationSessionContext"/></returns>
+        public async Task<ApplicationSessionContext> GetDelegatedServiceTicket(string spn)
+        {
+            return await this.GetDelegatedServiceTicket(new RequestServiceTicket { ServicePrincipalName = spn }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Request a service ticket from a KDC using TGS-REQ
+        /// </summary>
+        /// <param name="rst">The parameters of the request</param>
+        /// <param name="cancellation">A cancellation token to exit the request early</param>
+        /// <returns>Returns a <see cref="ApplicationSessionContext"/> containing the service ticket</returns>
+        public async Task<ApplicationSessionContext> GetDelegatedServiceTicket(
+            RequestServiceTicket rst,
+            CancellationToken cancellation = default
+        )
+        {
+            if (this.s4uProvider == null)
+            {
+                throw new InvalidOperationException("S4U is not configured for this identity");
+            }
+
+            //rst.S4uTarget = rst.ServicePrincipalName;
+            rst.S4uTicket = this.krbApReq.EncryptedTicket;
+            rst.KdcOptions |= KdcOptions.CNameInAdditionalTicket;
+
+            return await this.s4uProvider.GetServiceTicket(rst, cancellation);
+        }
     }
 }

--- a/Kerberos.NET/S4UProvider.cs
+++ b/Kerberos.NET/S4UProvider.cs
@@ -1,0 +1,41 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using Kerberos.NET.Client;
+using Kerberos.NET.Configuration;
+using Kerberos.NET.Credentials;
+using Kerberos.NET.Crypto;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kerberos.NET
+{
+    internal class S4UProvider : IS4UProvider
+    {
+        private readonly string upn;
+        private readonly KeyTable keytab;
+        private readonly Krb5Config config;
+        private readonly ILoggerFactory logger;
+
+
+        public S4UProvider(string upn, KeyTable keytab, Krb5Config config = null, ILoggerFactory logger = null)
+        {
+            this.upn = upn;
+            this.keytab = keytab;
+            this.config = config;
+            this.logger = logger;
+        }
+
+        public async Task<ApplicationSessionContext> GetServiceTicket(RequestServiceTicket rst, CancellationToken cancellation)
+        {
+            var client = new KerberosClient(this.config, this.logger) { CacheInMemory = true };
+
+            await client.Authenticate(new KeytabCredential(this.upn, this.keytab));
+
+            return await client.GetServiceTicket(rst, cancellation);
+        }
+    }
+}

--- a/Kerberos.NET/Strings.Designer.cs
+++ b/Kerberos.NET/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Kerberos.NET {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -120,6 +120,15 @@ namespace Kerberos.NET {
         internal static string ArgumentOutOfRange_NeedNonNegNum {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRange_NeedNonNegNum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The client has been referred to too many realms before it could find the requested service principal.
+        /// </summary>
+        internal static string ChasedReferralTooFar {
+            get {
+                return ResourceManager.GetString("ChasedReferralTooFar", resourceCulture);
             }
         }
         
@@ -921,6 +930,15 @@ namespace Kerberos.NET {
         internal static string ObjectDisposed_Generic {
             get {
                 return ResourceManager.GetString("ObjectDisposed_Generic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Both the S4UTarget and S4UTicket properties are present on the service ticket request which is not allowed. Set S4UTarget for invoking the S4USelf flow or otherwise set S4UTicket for the S4UProxy (constrained delegation) flow..
+        /// </summary>
+        internal static string S4uTargetTicketBothPresent {
+            get {
+                return ResourceManager.GetString("S4uTargetTicketBothPresent", resourceCulture);
             }
         }
     }

--- a/Kerberos.NET/Strings.resx
+++ b/Kerberos.NET/Strings.resx
@@ -405,4 +405,10 @@
   <data name="KRB_ERROR_KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED" xml:space="preserve">
     <value>The KDC does not support public key encryption for PKINIT</value>
   </data>
+  <data name="ChasedReferralTooFar" xml:space="preserve">
+    <value>The client has been referred to too many realms before it could find the requested service principal</value>
+  </data>
+  <data name="S4uTargetTicketBothPresent" xml:space="preserve">
+    <value>Both the S4UTarget and S4UTicket properties are present on the service ticket request which is not allowed. Set S4UTarget for invoking the S4USelf flow or otherwise set S4UTicket for the S4UProxy (constrained delegation) flow.</value>
+  </data>
 </root>

--- a/Tests/Tests.Kerberos.NET/CommandLine/CommandLineTests.cs
+++ b/Tests/Tests.Kerberos.NET/CommandLine/CommandLineTests.cs
@@ -114,7 +114,7 @@ namespace Tests.Kerberos.NET
             var types = LoadTypes();
             var io = InputControl.Default();
 
-            Assert.AreEqual(9, types.Count());
+            Assert.AreEqual(10, types.Count());
 
             foreach (var type in types)
             {

--- a/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading.Tasks;
 using Kerberos.NET;
 using Kerberos.NET.Client;
@@ -454,6 +455,25 @@ namespace Tests.Kerberos.NET
                     FakeAdminAtCorpPassword,
                     $"127.0.0.1:{port}",
                     s4u: "blah@corp.identityintervention.com"
+                );
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task E2E_S4U_BothTargetAndTicket()
+        {
+            var port = NextPort();
+
+            using (var listener = StartListener(port))
+            {
+                await RequestAndValidateTickets(
+                    listener,
+                    AdminAtCorpUserName,
+                    FakeAdminAtCorpPassword,
+                    $"127.0.0.1:{port}",
+                    s4u: "blah@corp.identityintervention.com",
+                    s4uTicket: new KrbTicket()
                 );
             }
         }

--- a/Tests/Tests.Kerberos.NET/End2End/KdcListenerTestBase.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/KdcListenerTestBase.cs
@@ -85,7 +85,8 @@ namespace Tests.Kerberos.NET
             KeyAgreementAlgorithm keyAgreement = KeyAgreementAlgorithm.DiffieHellmanModp14,
             bool allowWeakCrypto = false,
             bool useWeakCrypto = false,
-            bool mutualAuth = true
+            bool mutualAuth = true,
+            KrbTicket s4uTicket = null
         )
         {
             KerberosCredential kerbCred;
@@ -142,7 +143,8 @@ namespace Tests.Kerberos.NET
                     {
                         ServicePrincipalName = spn,
                         ApOptions = mutualAuth ? ApOptions.MutualRequired : 0,
-                        S4uTarget = s4u
+                        S4uTarget = s4u,
+                        S4uTicket = s4uTicket
                     }
                 );
 


### PR DESCRIPTION
### What's the problem?

S4U isn't behaving correctly when running against caches because the session key is getting set incorrectly.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Use the correct session key.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Partial fix for #276
