### PR TITLE
Linux doesn't support named semaphores

### DIFF
--- a/Kerberos.NET/Cache/FileHandle.cs
+++ b/Kerberos.NET/Cache/FileHandle.cs
@@ -4,7 +4,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -13,7 +12,6 @@ namespace Kerberos.NET.Client
     internal class FileHandle : IDisposable
     {
         private readonly Mutex mutex;
-        private readonly Semaphore semaphore;
 
         private readonly string file;
         private readonly FileMode mode;
@@ -22,7 +20,7 @@ namespace Kerberos.NET.Client
 
         private static readonly TimeSpan LockWaitTimeout = TimeSpan.FromMilliseconds(5000);
 
-        public FileHandle(string file, FileMode mode, FileAccess access, FileShare share, int maxReaders = 100)
+        public FileHandle(string file, FileMode mode, FileAccess access, FileShare share)
         {
             var mutexName = GetObjectName(file, "mutex");
 
@@ -35,99 +33,47 @@ namespace Kerberos.NET.Client
                 this.mutex = new Mutex(false, mutexName);
             }
 
-            var semaphoreName = GetObjectName(file, "semaphore");
-
-            if (Semaphore.TryOpenExisting(semaphoreName, out Semaphore semaphore))
-            {
-                this.semaphore = semaphore;
-            }
-            else
-            {
-                this.semaphore = new Semaphore(maxReaders, maxReaders, semaphoreName);
-            }
-
             this.file = file;
             this.mode = mode;
             this.access = access;
             this.share = share;
-
-            this.MaximumReaders = maxReaders;
         }
-
-        public int MaximumReaders { get; }
 
         public FileStream OpenStream()
         {
             return File.Open(this.file, this.mode, this.access, this.share);
         }
 
-        public IDisposable AcquireReadLock() => new ReadLock(this.mutex, this.semaphore);
+        public IDisposable AcquireReadLock() => new FileLock(this.mutex);
 
-        public IDisposable AcquireWriteLock()
-        {
-            return new WriteLock(this.mutex, this.semaphore, this.MaximumReaders);
-        }
+        public IDisposable AcquireWriteLock() => new FileLock(this.mutex);
 
         public void Dispose()
         {
             this.mutex.Dispose();
-            this.semaphore.Dispose();
         }
 
         private static string GetObjectName(string file, string type)
         {
-            return "Global\\" + type + "_" + file.Replace(Path.PathSeparator, '_')
-                                                 .Replace(Path.DirectorySeparatorChar, '_')
+            return "Global\\" + type + "_" + file.Replace(Path.DirectorySeparatorChar, '_')
                                                  .Replace(Path.AltDirectorySeparatorChar, '_')
                                                  .Replace(Path.VolumeSeparatorChar, '_');
         }
 
-        private class WriteLock : IDisposable
+        private class FileLock : IDisposable
         {
             private readonly Mutex mutex;
-            private readonly Semaphore semaphore;
-            private readonly int maximumReaders;
 
-            public WriteLock(Mutex mutex, Semaphore semaphore, int maximumReaders)
+            public FileLock(Mutex mutex)
             {
                 this.mutex = mutex;
-                this.semaphore = semaphore;
-                this.maximumReaders = maximumReaders;
 
                 this.mutex.WaitOne(LockWaitTimeout);
-
-                for (int i = 0; i < maximumReaders; i++)
-                {
-                    this.semaphore.WaitOne(LockWaitTimeout);
-                }
             }
 
             public void Dispose()
             {
                 this.mutex.ReleaseMutex();
-
-                this.semaphore.Release(this.maximumReaders);
-            }
-        }
-
-        private class ReadLock : IDisposable
-        {
-            private readonly Mutex mutex;
-            private readonly Semaphore semaphore;
-
-            public ReadLock(Mutex mutex, Semaphore semaphore)
-            {
-                this.mutex = mutex;
-                this.semaphore = semaphore;
-
-                this.mutex.WaitOne(LockWaitTimeout);
-                this.semaphore.WaitOne(LockWaitTimeout);
-                this.mutex.ReleaseMutex();
-            }
-
-            public void Dispose()
-            {
-                this.semaphore.Release();
             }
         }
     }


### PR DESCRIPTION
### What's the problem?

Linux doesn't support named semaphores in .NET so the previous change blows up whenever you try and read a cache file.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Stick to plain old named mutexes.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

N/A