### PR TITLE
Added config-based domain to realm mapping

### DIFF
--- a/Kerberos.NET/Dns/DnsQueryWin32.cs
+++ b/Kerberos.NET/Dns/DnsQueryWin32.cs
@@ -37,9 +37,9 @@ namespace Kerberos.NET.Dns
 
         private static readonly HashSet<int> IgnoredErrors = new HashSet<int>()
         {
-            9002, // server not found
-            9003, // record not found,
-            9501, // server not found
+            9002, // server not found (DNS_ERROR_RCODE_SERVER_FAILURE)
+            9003, // record not found (DNS_ERROR_RCODE_NAME_ERROR)
+            9501, // record not found (DNS_INFO_NO_RECORDS)
         };
 
         public static IReadOnlyCollection<DnsRecord> QuerySrvRecord(string query, DnsRecordType type, DnsQueryOptions options = DefaultOptions)

--- a/Kerberos.NET/Dns/DnsQueryWin32.cs
+++ b/Kerberos.NET/Dns/DnsQueryWin32.cs
@@ -38,7 +38,8 @@ namespace Kerberos.NET.Dns
         private static readonly HashSet<int> IgnoredErrors = new HashSet<int>()
         {
             9002, // server not found
-            9003, // record not found
+            9003, // record not found,
+            9501, // server not found
         };
 
         public static IReadOnlyCollection<DnsRecord> QuerySrvRecord(string query, DnsRecordType type, DnsQueryOptions options = DefaultOptions)

--- a/Tests/Tests.Kerberos.NET/KdcListener.cs
+++ b/Tests/Tests.Kerberos.NET/KdcListener.cs
@@ -54,13 +54,18 @@ namespace Tests.Kerberos.NET
             return new TcpKdcListener(server);
         }
 
-        public static KdcListener StartListener(int port, bool slow = false, bool allowWeakCrypto = false)
+        public static KdcListener StartListener(
+            int port,
+            bool slow = false,
+            bool allowWeakCrypto = false,
+            string realm = "corp2.identityintervention.com"
+        )
         {
             KdcServerOptions options = null;
 
             options = new KdcServerOptions
             {
-                DefaultRealm = "corp2.identityintervention.com".ToUpper(CultureInfo.InvariantCulture),
+                DefaultRealm = realm.ToUpper(CultureInfo.InvariantCulture),
                 IsDebug = true,
                 RealmLocator = realm => LocateRealm(realm, slow, options.Configuration)
             };


### PR DESCRIPTION
### What's the problem?

Sometimes the KDC doesn't know what realm to send a client to if the requested name doesn't end in something meaningful. The local client may already know this and should try and handle it.

- [ ] Bugfix
- [X] New Feature

### What's the solution?

If the client receives an authoritative SPN-not-found error it should check the local config to see if there's an existing mapping that knows it should go elsewhere, and then try that instead. This explicitly happens after the KDC check because the KDC is the authority in all cases and its opinion on where it should send you is always more important than what the local config thinks.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

N/A
