### PR TITLE
Add KerberosCompatibilityFlags to enforce uppercase realm name.

### DIFF
--- a/Kerberos.NET/Configuration/Krb5RealmConfig.cs
+++ b/Kerberos.NET/Configuration/Krb5RealmConfig.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Kerberos.NET.Server;
 
 namespace Kerberos.NET.Configuration
 {
@@ -345,5 +346,12 @@ namespace Kerberos.NET.Configuration
         [DisplayName("supported_enctypes")]
         public ICollection<KeySaltPair> KdcSupportedEncryptionTypes { get; private set; }
 
+        /// <summary>
+        /// Compatibility shims should be enforced by the KDC.
+        /// </summary>
+        [EnumAsInteger]
+        [DefaultValue(KerberosCompatibilityFlags.None)]
+        [DisplayName("compatibility_flags")]
+        public KerberosCompatibilityFlags CompatibilityFlags { get; set; }
     }
 }

--- a/Kerberos.NET/Entities/Krb/KrbAsRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsRep.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -30,6 +30,8 @@ namespace Kerberos.NET.Entities
             {
                 throw new ArgumentNullException(nameof(realmService));
             }
+
+            rst.Compatibility = realmService.Settings.Compatibility;
 
             // This is approximately correct such that a client doesn't barf on it
             // The krbtgt Ticket structure is probably correct as far as AD thinks

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities.Pac;
+using Kerberos.NET.Server;
 
 namespace Kerberos.NET.Entities
 {
@@ -92,6 +93,11 @@ namespace Kerberos.NET.Entities
             if (request.ServicePrincipalKey == null)
             {
                 throw new InvalidOperationException("A service principal key must be provided");
+            }
+
+            if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
+            {
+                request.RealmName = request.RealmName?.ToUpperInvariant();
             }
 
             var authz = GenerateAuthorizationData(request);

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -121,6 +121,11 @@ namespace Kerberos.NET.Entities
         public TimeSpan MaximumRenewalWindow { get; set; }
 
         /// <summary>
+        /// Indicates what compatibility modes if any the KDC should apply.
+        /// </summary>
+        public KerberosCompatibilityFlags Compatibility { get; set; }
+
+        /// <summary>
         /// Validate the lifetime values are within spec and if not set them to be valid.
         /// </summary>
         public void ClampLifetime()
@@ -259,6 +264,11 @@ namespace Kerberos.NET.Entities
                 return false;
             }
 
+            if (other.Compatibility != this.Compatibility)
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -283,7 +293,8 @@ namespace Kerberos.NET.Entities
                 this.SamAccountName,
                 this.ServicePrincipal,
                 this.ServicePrincipalKey,
-                this.StartTime
+                this.StartTime,
+                this.Compatibility
             );
         }
 

--- a/Kerberos.NET/Server/DefaultRealmSettings.cs
+++ b/Kerberos.NET/Server/DefaultRealmSettings.cs
@@ -10,21 +10,11 @@ namespace Kerberos.NET.Server
     {
         private readonly Krb5ConfigDefaults defaults;
         private readonly Krb5RealmConfig config;
-        private readonly KerberosCompatibilityFlags compatibilityFlags;
 
         public DefaultRealmSettings(Krb5ConfigDefaults defaults, Krb5RealmConfig config)
-            : this(defaults, config, KerberosCompatibilityFlags.None)
-        {
-        }
-
-        public DefaultRealmSettings(
-            Krb5ConfigDefaults defaults,
-            Krb5RealmConfig config,
-            KerberosCompatibilityFlags compatibilityFlags)
         {
             this.defaults = defaults;
             this.config = config;
-            this.compatibilityFlags = compatibilityFlags;
         }
 
         /// <inheritdoc />
@@ -37,6 +27,6 @@ namespace Kerberos.NET.Server
         public TimeSpan MaximumRenewalWindow => this.config.KdcMaxRenewableLifetime;
 
         /// <inheritdoc />
-        public KerberosCompatibilityFlags Compatibility => this.compatibilityFlags;
+        public KerberosCompatibilityFlags Compatibility => this.config.CompatibilityFlags;
     }
 }

--- a/Kerberos.NET/Server/DefaultRealmSettings.cs
+++ b/Kerberos.NET/Server/DefaultRealmSettings.cs
@@ -10,11 +10,21 @@ namespace Kerberos.NET.Server
     {
         private readonly Krb5ConfigDefaults defaults;
         private readonly Krb5RealmConfig config;
+        private readonly KerberosCompatibilityFlags compatibilityFlags;
 
         public DefaultRealmSettings(Krb5ConfigDefaults defaults, Krb5RealmConfig config)
+            : this(defaults, config, KerberosCompatibilityFlags.None)
+        {
+        }
+
+        public DefaultRealmSettings(
+            Krb5ConfigDefaults defaults,
+            Krb5RealmConfig config,
+            KerberosCompatibilityFlags compatibilityFlags)
         {
             this.defaults = defaults;
             this.config = config;
+            this.compatibilityFlags = compatibilityFlags;
         }
 
         /// <inheritdoc />
@@ -25,5 +35,8 @@ namespace Kerberos.NET.Server
 
         /// <inheritdoc />
         public TimeSpan MaximumRenewalWindow => this.config.KdcMaxRenewableLifetime;
+
+        /// <inheritdoc />
+        public KerberosCompatibilityFlags Compatibility => this.compatibilityFlags;
     }
 }

--- a/Kerberos.NET/Server/IRealmService.cs
+++ b/Kerberos.NET/Server/IRealmService.cs
@@ -102,6 +102,11 @@ namespace Kerberos.NET.Server
         /// The maximum length of time a ticket can be renewed if enabled. Default is 7 days.
         /// </summary>
         TimeSpan MaximumRenewalWindow { get; }
+
+        /// <summary>
+        /// Indicates the compatibility shims the KDC should enforce.
+        /// </summary>
+        KerberosCompatibilityFlags Compatibility { get; }
     }
 
     public interface IKerberosPrincipal

--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -183,6 +183,7 @@ namespace Kerberos.NET.Server
                     this.RealmService.Configuration.Defaults.PermittedEncryptionTypes,
                     this.RealmService.Configuration.Defaults.AllowWeakCrypto
                 ),
+                Compatibility = this.RealmService.Settings.Compatibility,
             };
 
             if (context.ClientAuthority != PaDataType.PA_NONE)

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -284,6 +284,7 @@ namespace Kerberos.NET.Server
                     this.RealmService.Configuration.Defaults.PermittedEncryptionTypes,
                     this.RealmService.Configuration.Defaults.AllowWeakCrypto
                 ),
+                Compatibility = this.RealmService.Settings.Compatibility,
             };
 
             // this is set here instead of in GenerateServiceTicket because GST is used by unit tests to

--- a/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
+++ b/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
@@ -1,0 +1,26 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Kerberos.NET.Server
+{
+    /// <summary>
+    /// Identifies which compatibility shims should be enforced by the KDC.
+    /// </summary>
+    [Flags]
+    public enum KerberosCompatibilityFlags
+    {
+        /// <summary>
+        /// Do not enforce any compatibility shims.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Always uppercase realm names.
+        /// </summary>
+        NormalizeRealmsUppercase = 1 << 0,
+    }
+}

--- a/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
+++ b/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using Kerberos.NET.Configuration;
 using Kerberos.NET.Crypto;
+using Kerberos.NET.Server;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.Kerberos.NET
@@ -102,6 +103,7 @@ namespace Tests.Kerberos.NET
             Assert.AreEqual(1, obj.CaPaths.Count);
             Assert.AreEqual(".", obj.CaPaths["EXAMPLE.COM"]["DEV.EXAMPLE.COM"]);
             Assert.AreEqual(".", obj.CaPaths["EXAMPLE.COM"]["TEST.EXAMPLE.COM"]);
+            Assert.AreEqual(KerberosCompatibilityFlags.NormalizeRealmsUppercase, obj.Realms["EXAMPLE.COM"].CompatibilityFlags);
         }
 
         [TestMethod]

--- a/Tests/Tests.Kerberos.NET/Data/Configuration/krb5.conf
+++ b/Tests/Tests.Kerberos.NET/Data/Configuration/krb5.conf
@@ -76,6 +76,8 @@ EXAMPLE.COM = {
             rcmd = bar
         }
     }
+
+    compatibility_flags = 1
 }
 
 [capaths]

--- a/Tests/Tests.Kerberos.NET/FakeRealmService.cs
+++ b/Tests/Tests.Kerberos.NET/FakeRealmService.cs
@@ -11,13 +11,16 @@ namespace Tests.Kerberos.NET
 {
     public class FakeRealmService : IRealmService
     {
-        public FakeRealmService(string realm, Krb5Config config = null)
+        private readonly KerberosCompatibilityFlags compatibilityFlags;
+
+        public FakeRealmService(string realm, Krb5Config config = null, KerberosCompatibilityFlags compatibilityFlags = KerberosCompatibilityFlags.None)
         {
             this.Name = realm;
             this.Configuration = config ?? Krb5Config.Kdc();
+            this.compatibilityFlags = compatibilityFlags;
         }
 
-        public IRealmSettings Settings => new FakeRealmSettings();
+        public IRealmSettings Settings => new FakeRealmSettings(this.compatibilityFlags);
 
         public IPrincipalService Principals => new FakePrincipalService(this.Name);
 

--- a/Tests/Tests.Kerberos.NET/FakeRealmSettings.cs
+++ b/Tests/Tests.Kerberos.NET/FakeRealmSettings.cs
@@ -10,10 +10,19 @@ namespace Tests.Kerberos.NET
 {
     internal class FakeRealmSettings : IRealmSettings
     {
+        private readonly KerberosCompatibilityFlags compatibilityFlags;
+
+        public FakeRealmSettings(KerberosCompatibilityFlags compatibilityFlags)
+        {
+            this.compatibilityFlags = compatibilityFlags;
+        }
+
         public TimeSpan MaximumSkew => TimeSpan.FromMinutes(5);
 
         public TimeSpan SessionLifetime => TimeSpan.FromHours(10);
 
         public TimeSpan MaximumRenewalWindow => TimeSpan.FromDays(7);
+
+        public KerberosCompatibilityFlags Compatibility => this.compatibilityFlags;
     }
 }

--- a/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -6,6 +6,7 @@
 using System;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
+using Kerberos.NET.Server;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests.Kerberos.NET
@@ -13,6 +14,9 @@ namespace Tests.Kerberos.NET
     [TestClass]
     public class KrbKdcRepTests
     {
+        private const string LowerCaseRealm = "realm.com";
+        private const string UpperCaseRealm = "REALM.COM";
+
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void CreateServiceTicket_NullEncPartKey()
@@ -78,6 +82,29 @@ namespace Tests.Kerberos.NET
             });
 
             Assert.IsNotNull(ticket);
+        }
+
+        [DataTestMethod]
+        [DataRow(LowerCaseRealm, KerberosCompatibilityFlags.None, LowerCaseRealm)]
+        [DataRow(LowerCaseRealm, KerberosCompatibilityFlags.NormalizeRealmsUppercase, UpperCaseRealm)]
+        [DataRow(UpperCaseRealm, KerberosCompatibilityFlags.None, UpperCaseRealm)]
+        [DataRow(UpperCaseRealm, KerberosCompatibilityFlags.NormalizeRealmsUppercase, UpperCaseRealm)]
+        public void CreateServiceTicketOnCompatibilitySetting(string realm, KerberosCompatibilityFlags compatibilityFlags, string expectedRealm)
+        {
+            var key = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96).AsKey();
+
+            var ticket = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
+            {
+                EncryptedPartKey = key,
+                ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
+                ServicePrincipalKey = key,
+                Principal = new FakeKerberosPrincipal("blah@blah2.com"),
+                RealmName = realm,
+                Compatibility = compatibilityFlags,
+            });
+
+            Assert.IsNotNull(ticket);
+            Assert.AreEqual(expectedRealm, ticket.CRealm);
         }
     }
 }


### PR DESCRIPTION
### What's the problem?
KDC may receive request with realm name in lower case and will generate a Ticket with Realm Name based on the value received in request. 

- [ ] Bugfix
- [X] New Feature

### What's the solution?
To allow to return the Realm Name following the uppercase convention, add an additional configuration for compatibility on the realm level that would Uppercase the realm name prior to generation of the ticket.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?
N/A
