### PR TITLE
Clean rented buffer during PAC generation.

### DIFF
--- a/Kerberos.NET/Asn1/Experimental/CryptoPool.cs
+++ b/Kerberos.NET/Asn1/Experimental/CryptoPool.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -14,7 +14,14 @@ namespace System.Security.Cryptography
 
         internal static byte[] Rent(int minimumLength) => SharedRent<byte>(minimumLength);
 
-        internal static T[] SharedRent<T>(int minimumLength) => ArrayPool<T>.Shared.Rent(minimumLength);
+        internal static T[] SharedRent<T>(int minimumLength)
+        {
+            var rentedBuffer = ArrayPool<T>.Shared.Rent(minimumLength);
+            Array.Clear(rentedBuffer, 0, rentedBuffer.Length);
+
+            return rentedBuffer;
+        }
+
 
         internal static IMemoryOwner<T> Rent<T>(int minimumLength) => new CryptoMemoryOwner<T>(minimumLength);
 


### PR DESCRIPTION
### What's the problem?
System.Security.SecurityException: Invalid checksum    at Kerberos.NET.Crypto.KerberosChecksum.Validate(KerberosKey key)

GeneratePac is called twice in the PrivilegedAttributeCertificate.Encode method. First time prior to signing and the second time after signing.
Because CryptoPool uses ArrayPool<T>.Shared to get a memory buffer for the pac data it might retrieve an empty or non empty buffer (if ArrayPool<T>.Shared.Return was used without clean data flag) and because of the alignment the memory buffer is not completely overwritten and might contain some data from the rented buffer. Resulting in differences in the data that was used to generate a checksum and the final encoded pac and consequently failed checksum verification.

- [X] Bugfix
- [ ] New Feature

### What's the solution?
Reset the buffer to default values (0 for bytes) to remove variability in the rented buffer.

 - [ ] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?
N/A
