### PR TITLE
Time stamp the PreAuth errors

### DIFF
--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -236,6 +236,8 @@ namespace Kerberos.NET.Server
                 SName = KrbPrincipalName.FromPrincipal(context.Principal)
             };
 
+            err.StampServerTime();
+
             return err.EncodeApplication();
         }
 
@@ -254,6 +256,8 @@ namespace Kerberos.NET.Server
                     MethodData = context.PaData.ToArray()
                 }.Encode()
             };
+
+            err.StampServerTime();
 
             return err.EncodeApplication();
         }


### PR DESCRIPTION
The kdc_timesync mechanism in krb5 uses the timestamp to detect a time skew between server and client.

### What's the problem?

Describe the problem here.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Describe the solution here.

 - [ ] Includes unit tests
 - [x] Requires manual test

### What issue is this related to, if any?

Found this when trying to get [simple loopback authentication](https://github.com/filipnavara/KerberosLoopback) working with the krb5 library on Linux.