### PR TITLE
Fix CName propagation in TGS-REQ for krb5 compatibility

### DIFF
--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -287,6 +287,11 @@ namespace Kerberos.NET.Server
                 Compatibility = this.RealmService.Settings.Compatibility,
             };
 
+            if (tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
+            {
+                rst.SamAccountName = context.GetState<TgsState>(PaDataType.PA_TGS_REQ).DecryptedApReq.Ticket.CName.FullyQualifiedName;
+            }
+
             // this is set here instead of in GenerateServiceTicket because GST is used by unit tests to
             // generate tickets with weird lifetimes for scenario testing and we don't want to break that
 


### PR DESCRIPTION
### What's the problem?

Authentication with KRB5 against Kerberos.NET KDC was not working due to failing ticket validation.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Describe the solution here.

 - [ ] Includes unit tests
 - [x] Requires manual test

### What issue is this related to, if any?

Fixes #302