### PR TITLE
Only reverse its read on little endian because BinaryReader already does this

### DIFF
--- a/Kerberos.NET/Crypto/KeyEntry.cs
+++ b/Kerberos.NET/Crypto/KeyEntry.cs
@@ -162,7 +162,10 @@ namespace Kerberos.NET.Crypto
         {
             var bytes = reader.ReadBytes(4);
 
-            Array.Reverse(bytes);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
 
             return BitConverter.ToInt32(bytes, 0);
         }
@@ -171,7 +174,10 @@ namespace Kerberos.NET.Crypto
         {
             var bytes = reader.ReadBytes(2);
 
-            Array.Reverse(bytes);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
 
             return BitConverter.ToInt16(bytes, 0);
         }
@@ -256,7 +262,10 @@ namespace Kerberos.NET.Crypto
         {
             var bytes = BitConverter.GetBytes(val);
 
-            Array.Reverse(bytes);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
 
             writer.Write(bytes);
         }
@@ -265,7 +274,10 @@ namespace Kerberos.NET.Crypto
         {
             var bytes = BitConverter.GetBytes(val);
 
-            Array.Reverse(bytes);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
 
             writer.Write(bytes);
         }


### PR DESCRIPTION
### What's the problem?

https://github.com/dotnet/runtime/issues/73343

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Only reverse when its a little endian machine.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

https://github.com/dotnet/runtime/issues/73343
