### PR TITLE
Release the security context from [SspiSecurityContext.InitializeSeucrityContext] on disposal

### DIFF
--- a/Kerberos.NET/Win32/SspiSecurityContext.cs
+++ b/Kerberos.NET/Win32/SspiSecurityContext.cs
@@ -228,6 +228,8 @@ namespace Kerberos.NET.Win32
                 }
                 while (result == SecStatus.SEC_I_INCOMPLETE_CREDENTIALS || result == SecStatus.SEC_E_INSUFFICENT_MEMORY);
 
+                this.TrackUnmanaged(this.securityContext);
+
                 if (result > SecStatus.SEC_E_ERROR)
                 {
                     throw new Win32Exception((int)result);


### PR DESCRIPTION
### What's the problem?

Security contexts initialized by [InitializeSecurityContext] don't seem to be released when the object is disposed. 

- [X] Bugfix
- [ ] New Feature

### What's the solution?

[AcceptSecurityContext] in the same file has a line that tracks the resource so it does get released properly. The two functions' code flows are mostly the same, so I added the line to the other function.

- [ ] Includes unit tests
- [X] Requires manual test

### What issue is this related to, if any?

I'm using Kerberos.NET's bindings here to request auth tokens repeatedly to many different servers. We'd create security contexts just for the Kerberos handshake, then dispose them right after. Someone noticed that this causes the memory and handle count of the Local Security Authority process to balloon. With this line, the resource usage is stable.

I'm not sure how to easily unit-test this change -- we observed this as a leak vs. something correctness-related. That said, I'm happy to contribute a test if you have pointers.