### PR TITLE
Initial support for `dns_canonicalize_hostname = fallback`

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -516,7 +516,7 @@ namespace Kerberos.NET.Client
 
             var requestedServicePrincipalName = KrbPrincipalName.FromString(rst.ServicePrincipalName);
 
-            if (this.Configuration.Defaults.DnsCanonicalizeHostname)
+            if (this.Configuration.Defaults.DnsCanonicalizeHostname != DnsCanonicalization.False)
             {
                 requestedServicePrincipalName.Canonicalize(this.Configuration.Defaults.QualifyShortname);
 

--- a/Kerberos.NET/Configuration/DnsCanonicalization.cs
+++ b/Kerberos.NET/Configuration/DnsCanonicalization.cs
@@ -1,0 +1,23 @@
+﻿namespace Kerberos.NET.Configuration
+{
+    /// <summary>
+    /// Possible values for <see cref="Krb5ConfigDefaults.DnsCanonicalizeHostname"/>
+    /// </summary>
+    public enum DnsCanonicalization
+    {
+        /// <summary>
+        /// Canonicalization disabled.
+        /// </summary>
+        False,
+
+        /// <summary>
+        /// Canonicalization enabled.
+        /// </summary>
+        True,
+
+        /// <summary>
+        /// DNS canonicalization will only be performed the server hostname is not found with the original name when requesting credentials.
+        /// </summary>
+        Fallback
+    }
+}

--- a/Kerberos.NET/Configuration/Krb5ConfigDefaults.cs
+++ b/Kerberos.NET/Configuration/Krb5ConfigDefaults.cs
@@ -101,13 +101,14 @@ namespace Kerberos.NET.Configuration
 
         /// <summary>
         /// Indicate whether name lookups will be used to canonicalize hostnames for use in service
-        /// principal names. Setting this flag to false can improve security by reducing reliance on
+        /// principal names. Setting this flag to False can improve security by reducing reliance on
         /// DNS, but means that short hostnames will not be canonicalized to fully-qualified hostnames.
-        /// The default value is false.
+        /// Value <see cref="DnsCanonicalization.Fallback"/> is currently equivalent to True.
+        /// The default value is <see cref="DnsCanonicalization.False"/>.
         /// </summary>
-        [DefaultValue(false)]
+        [DefaultValue(DnsCanonicalization.False)]
         [DisplayName("dns_canonicalize_hostname")]
-        public bool DnsCanonicalizeHostname { get; set; }
+        public DnsCanonicalization DnsCanonicalizeHostname { get; set; }
 
         /// <summary>
         /// Indicate whether DNS SRV records should be used to locate the KDCs and other servers for a realm,

--- a/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
+++ b/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
@@ -103,6 +103,7 @@ namespace Tests.Kerberos.NET
             Assert.AreEqual(1, obj.CaPaths.Count);
             Assert.AreEqual(".", obj.CaPaths["EXAMPLE.COM"]["DEV.EXAMPLE.COM"]);
             Assert.AreEqual(".", obj.CaPaths["EXAMPLE.COM"]["TEST.EXAMPLE.COM"]);
+            Assert.AreEqual(DnsCanonicalization.Fallback, obj.Defaults.DnsCanonicalizeHostname);
             Assert.AreEqual(KerberosCompatibilityFlags.NormalizeRealmsUppercase, obj.Realms["EXAMPLE.COM"].CompatibilityFlags);
         }
 

--- a/Tests/Tests.Kerberos.NET/Data/Configuration/krb5.conf
+++ b/Tests/Tests.Kerberos.NET/Data/Configuration/krb5.conf
@@ -21,6 +21,8 @@ commented_enctypes = aes256-cts-hmac-sha1-96 #aes128-cts-hmac-sha1-96 des3-cbc-s
 
 spake_preauth_groups = edwards25519 P-256 P-384 P-521
 
+dns_canonicalize_hostname = fallback
+
 [kdcdefaults]
     kdc_listen = 88
     kdc_tcp_listen = 88
@@ -54,7 +56,7 @@ EXAMPLE.COM = {
     kdc = srv-kdc-2.EXAMPLE.COM:88
     kdc = srv-kdc-3.EXAMPLE.COM:88*
     kdc = srv-kdc-ignored.EXAMPLE.COM:88*
-    
+
     master_kdc = srv-kdc-admin.EXAMPLE.COM:88
     admin_server = srv-kdc-admin.EXAMPLE.COM
     default_domain = EXAMPLE.COM


### PR DESCRIPTION
This allows successful de-serialisation of `krb5.conf` (for example via `Krb5Config.CurrentUser()`) on Linux systems that come with `fallback` as the default value.

`fallback` is currently treated the same as `true`.

### What's the problem?

Before this change, and exception would be thrown when de-serialising `/etc/krb5.conf` on a fresh RHEL 9 installation.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Simply allows the new `fallback` value.

 - [x] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #329 
