### PR TITLE
Sequence signature checks later

### DIFF
--- a/Kerberos.NET/Entities/Pac/PacSignature.cs
+++ b/Kerberos.NET/Entities/Pac/PacSignature.cs
@@ -40,7 +40,7 @@ namespace Kerberos.NET.Entities.Pac
         public ReadOnlyMemory<byte> SignatureData { get; set; }
 
         [KerberosIgnore]
-        public KerberosChecksum Validator { get; set; }
+        protected KerberosChecksum Validator { get; set; }
 
         public ChecksumType Type { get; set; }
 
@@ -86,8 +86,6 @@ namespace Kerberos.NET.Entities.Pac
             {
                 this.Signature = SetSignatureValue(this.Type, size => stream.ReadFixedPrimitiveArray<byte>(size).ToArray());
 
-                this.Validator = CryptoService.CreateChecksum(this.Type, this.Signature, this.SignatureData);
-
                 if (stream.BytesAvailable > 0)
                 {
                     this.RODCIdentifier = stream.ReadInt16LittleEndian();
@@ -101,6 +99,8 @@ namespace Kerberos.NET.Entities.Pac
 
         public void Validate(KerberosKey key)
         {
+            this.Validator = CryptoService.CreateChecksum(this.Type, this.Signature, this.SignatureData);
+
             if (this.Validator == null)
             {
                 throw new InvalidOperationException($"Validator not set for checksum type {this.Type}");

--- a/Kerberos.NET/Ndr/PacObject.cs
+++ b/Kerberos.NET/Ndr/PacObject.cs
@@ -40,6 +40,8 @@ namespace Kerberos.NET.Entities.Pac
 
         internal bool IsDirty { get; set; }
 
+        internal long Offset { get; set; }
+
         private ReadOnlyMemory<byte> cachedEncodedValue;
 
         public virtual ReadOnlyMemory<byte> Encode()

--- a/Tests/Tests.Kerberos.NET/Pac/PacTests.cs
+++ b/Tests/Tests.Kerberos.NET/Pac/PacTests.cs
@@ -99,7 +99,7 @@ namespace Tests.Kerberos.NET
 
             Assert.IsTrue(pacValidated);
 
-            GenerateCorruptPac(AES128PACSIGNATURE, AES128PAC).Validator.Validate(kerbKey);
+            GenerateCorruptPac(AES128PACSIGNATURE, AES128PAC).Validate(kerbKey);
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace Tests.Kerberos.NET
 
             Assert.IsTrue(pacValidated);
 
-            GenerateCorruptPac(AES256PACSIGNATURE, AES256PAC).Validator.Validate(kerbKey);
+            GenerateCorruptPac(AES256PACSIGNATURE, AES256PAC).Validate(kerbKey);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace Tests.Kerberos.NET
 
             Assert.IsTrue(pacValidated);
 
-            GenerateCorruptPac(RC4PACSIGNATURE, RC4PAC).Validator.Validate(kerbKey);
+            GenerateCorruptPac(RC4PACSIGNATURE, RC4PAC).Validate(kerbKey);
         }
 
         private static bool ValidatePac(KerberosKey kerbKey, byte[] infoBufferBytes, byte[] pacBytes)
@@ -147,7 +147,7 @@ namespace Tests.Kerberos.NET
             {
                 var sig = new PacSignature() { SignatureData = pacBytes };
                 sig.Unmarshal(infoBufferBytes);
-                sig.Validator.Validate(kerbKey);
+                sig.Validate(kerbKey);
                 pacValidated = true;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -258,9 +258,6 @@ namespace Tests.Kerberos.NET
 
             var encoded = pac.Encode(kdcKey, serverKey);
 
-            CryptoService.UnregisterChecksumAlgorithm((ChecksumType)(-1));
-            CryptoService.UnregisterCryptographicAlgorithm((EncryptionType)(-1));
-
             var roundtrip = new PrivilegedAttributeCertificate(
                 new KrbAuthorizationData
                 {
@@ -275,6 +272,9 @@ namespace Tests.Kerberos.NET
             roundtrip.ServerSignature.Validate(serverKey);
 
             Assert.AreEqual((ChecksumType)(-1), roundtrip.KdcSignature.Type);
+
+            CryptoService.UnregisterChecksumAlgorithm((ChecksumType)(-1));
+            CryptoService.UnregisterCryptographicAlgorithm((EncryptionType)(-1));
 
             bool threw = false;
 
@@ -374,8 +374,8 @@ namespace Tests.Kerberos.NET
 
             var pacDecoded = new PrivilegedAttributeCertificate(new KrbAuthorizationData { Type = AuthorizationDataType.AdWin2kPac, Data = encoded });
 
-            pacDecoded.ServerSignature.Validator.Validate(key);
-            pacDecoded.KdcSignature.Validator.Validate(key);
+            pacDecoded.ServerSignature.Validate(key);
+            pacDecoded.KdcSignature.Validate(key);
         }
 
         [TestMethod]


### PR DESCRIPTION
### What's the problem?

11B introduced a new signature type to cover the PAC using the privilege key. This breaks ordering of checks and results in a NRE.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Move the processing of signatures until after the whole PAC is parsed.

 - [X] Includes unit tests
 - [ ] Requires manual test
