### PR TITLE
Added flag to revert canonicalization check

### DIFF
--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -287,7 +287,11 @@ namespace Kerberos.NET.Server
                 Compatibility = this.RealmService.Settings.Compatibility,
             };
 
-            if (tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
+            // this introduced an annoying regression in a separate party and this is a workaround to make sure it
+            // uses the original behavior in cases where that's expected
+
+            if (!this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.DoNotCanonicalizeTgsReqFromTgt) &&
+                tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
                 rst.SamAccountName = context.GetState<TgsState>(PaDataType.PA_TGS_REQ).DecryptedApReq.Ticket.CName.FullyQualifiedName;
             }

--- a/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
+++ b/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
@@ -22,5 +22,10 @@ namespace Kerberos.NET.Server
         /// Always uppercase realm names.
         /// </summary>
         NormalizeRealmsUppercase = 1 << 0,
+
+        /// <summary>
+        /// Do not copy the name from the TGT if the canonicalize bit is set
+        /// </summary>
+        DoNotCanonicalizeTgsReqFromTgt = 1 << 1,
     }
 }


### PR DESCRIPTION
### What's the problem?

Canonicalization from TGT caused a regression in a separate product.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Adding a flag to back that out while the issue is further investigated.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Related to #302 
