### PR TITLE
DNS: Add POSIX DNS implementation

### DIFF
--- a/Bruce/Bruce.csproj
+++ b/Bruce/Bruce.csproj
@@ -12,6 +12,8 @@
     <Product>Kerberos.NET Command Line Tool</Product>
     <Description>A command line tool that manages the cross-platform, managed-code Kerberos Ticket parsing, validation, and authentication library Kerberos.NET.</Description>
     <PackageTags>security kerberos</PackageTags>
+    <LangVersion>9</LangVersion>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('Windows'))">WINDOWS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,6 +40,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Kerberos.NET\Kerberos.NET.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <ProjectReference Include="..\Samples\KerbDumpCore\KerbDumpCore.csproj" />
   </ItemGroup>
 

--- a/Bruce/CommandLine/KerberosDumpCommand.cs
+++ b/Bruce/CommandLine/KerberosDumpCommand.cs
@@ -4,8 +4,10 @@
 // -----------------------------------------------------------------------
 
 using System.Threading.Tasks;
+#if WINDOWS
 using System.Windows.Forms;
 using KerbDump;
+#endif
 
 namespace Kerberos.NET.CommandLine
 {
@@ -14,8 +16,10 @@ namespace Kerberos.NET.CommandLine
     {
         static KerberosDumpCommand()
         {
+#if WINDOWS
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+#endif
         }
 
         public KerberosDumpCommand(CommandLineParameters parameters)
@@ -34,6 +38,7 @@ namespace Kerberos.NET.CommandLine
                 return Task.FromResult(false);
             }
 
+#if WINDOWS
             using (var form = new DecoderForm()
             {
                 Ticket = this.Ticket,
@@ -42,6 +47,7 @@ namespace Kerberos.NET.CommandLine
             {
                 Application.Run(form);
             }
+#endif
 
             return Task.FromResult(true);
         }

--- a/Bruce/Dns/PlatformIndependentDnsClient.cs
+++ b/Bruce/Dns/PlatformIndependentDnsClient.cs
@@ -11,6 +11,8 @@ namespace Kerberos.NET.CommandLine.Dns
     {
         private static readonly WindowsDnsQuery WindowsDns = new WindowsDnsQuery();
 
+        public bool Debug { get; set; }
+
         public async Task<IReadOnlyCollection<DnsRecord>> Query(string query, DnsRecordType type)
         {
             if (WindowsDns.IsSupported)

--- a/Kerberos.NET/Dns/DnsQuery.cs
+++ b/Kerberos.NET/Dns/DnsQuery.cs
@@ -22,6 +22,7 @@ namespace Kerberos.NET.Dns
             if (OSPlatform.IsWindows)
             {
                 QueryImplementation = new WindowsDnsQuery();
+                return;
             }
             //for now assume it's POSIX
             QueryImplementation = new POSIXDnsQuery();

--- a/Kerberos.NET/Dns/DnsQuery.cs
+++ b/Kerberos.NET/Dns/DnsQuery.cs
@@ -23,6 +23,8 @@ namespace Kerberos.NET.Dns
             {
                 QueryImplementation = new WindowsDnsQuery();
             }
+            //for now assume it's POSIX
+            QueryImplementation = new POSIXDnsQuery();
         }
 
         public static bool Debug

--- a/Kerberos.NET/Dns/DnsQuery.cs
+++ b/Kerberos.NET/Dns/DnsQuery.cs
@@ -30,8 +30,8 @@ namespace Kerberos.NET.Dns
 
         public static bool Debug
         {
-            get => DnsQueryWin32.Debug;
-            set => DnsQueryWin32.Debug = value;
+            get => QueryImplementation.Debug;
+            set => QueryImplementation.Debug = value;
         }
 
         /// <summary>

--- a/Kerberos.NET/Dns/DnsQueryPOSIX.cs
+++ b/Kerberos.NET/Dns/DnsQueryPOSIX.cs
@@ -12,218 +12,221 @@ using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Kerberos.NET.Dns;
-
-public unsafe class DnsQueryPOSIX
+namespace Kerberos.NET.Dns
 {
-    private const int NS_PACKETSZ = 512;
-    private const int NS_MAXDNAME = 1025;
-
-    private const string LIBC = "libc.so";
-
-    [DllImport(LIBC, EntryPoint = "res_query")]
-    private static extern short ResQuery(
-        [MarshalAs(UnmanagedType.LPStr)] string dname,
-        NsClass @class,
-        DnsRecordType type,
-        char[] answer,
-        int anslen
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_initparse")]
-    private static extern short NsInitParse(
-        // [MarshalAs(UnmanagedType.LPStr)] string msg,
-        char[] msg,
-        short msglen,
-        NsMsg* handle
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_msg_count")]
-    private static extern ushort NsMsgCount(
-        NsMsg handle,
-        NsSect section
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_parserr")]
-    private static extern short NsParserr(
-        NsMsg* handle,
-        NsSect section,
-        short rrnum,
-        NsRr* rr
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_rr_type")]
-    private static extern DnsRecordType NsRrType(
-        NsRr rr
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_msg_base")]
-    private static extern string NsMsgBase(
-        NsMsg handle
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_msg_end")]
-    private static extern string NsMsgEnd(
-        NsMsg handle
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_rr_rdata")]
-    private static extern string NsRrRdata(
-        NsRr rr
-    );
-
-    [DllImport(LIBC, EntryPoint = "dn_expand")]
-    private static extern short DnExpand(
-        [MarshalAs(UnmanagedType.LPStr)] string msg,
-        [MarshalAs(UnmanagedType.LPStr)] string eomorig,
-        [MarshalAs(UnmanagedType.LPStr)] string comp_dn,
-        StringBuilder exp_dn,
-        short length
-    );
-
-    [DllImport(LIBC, EntryPoint = "ns_rr_name")]
-    private static extern string NsRrName(
-        NsRr rr
-    );
-
-    [DllImport(LIBC, EntryPoint = "inet_ntoa")]
-    private static extern string InetNToA(
-        InAddr @in
-    );
-
-    public static IReadOnlyCollection<DnsRecord> QuerySrvRecord(
-        string query,
-        DnsRecordType type,
-        DnsQueryOptions options = DnsQueryOptions.BypassCache)
+    public unsafe class DnsQueryPOSIX
     {
-        var list = new List<DnsRecord>();
-        var buffer = new char[NS_PACKETSZ];
+        private const int NS_PACKETSZ = 512;
+        private const int NS_MAXDNAME = 1025;
 
-        short respLen = -1;
-        if ((respLen = ResQuery(query, NsClass.NsCIn, type, buffer, NS_PACKETSZ)) < 0)
-            throw new Exception($"Query for {query} failed!");
+        private const string LIBC = "libc.so";
 
-        NsMsg handle;
-        if (NsInitParse(buffer, respLen, &handle) < 0)
-            throw new Exception("Failed to parse response buffer!");
+        [DllImport(LIBC, EntryPoint = "res_query")]
+        private static extern short ResQuery(
+            [MarshalAs(UnmanagedType.LPStr)] string dname,
+            NsClass @class,
+            DnsRecordType type,
+            char[] answer,
+            int anslen
+        );
 
-        var count = NsMsgCount(handle, NsSect.NsSAn);
-        Debug.WriteLine($"{count} records returned in the answer section.");
+        [DllImport(LIBC, EntryPoint = "ns_initparse")]
+        private static extern short NsInitParse(
+            // [MarshalAs(UnmanagedType.LPStr)] string msg,
+            char[] msg,
+            short msglen,
+            NsMsg* handle
+        );
 
-        for (short i = 0; i < count; i++)
+        [DllImport(LIBC, EntryPoint = "ns_msg_count")]
+        private static extern ushort NsMsgCount(
+            NsMsg handle,
+            NsSect section
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_parserr")]
+        private static extern short NsParserr(
+            NsMsg* handle,
+            NsSect section,
+            short rrnum,
+            NsRr* rr
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_rr_type")]
+        private static extern DnsRecordType NsRrType(
+            NsRr rr
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_msg_base")]
+        private static extern string NsMsgBase(
+            NsMsg handle
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_msg_end")]
+        private static extern string NsMsgEnd(
+            NsMsg handle
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_rr_rdata")]
+        private static extern string NsRrRdata(
+            NsRr rr
+        );
+
+        [DllImport(LIBC, EntryPoint = "dn_expand")]
+        private static extern short DnExpand(
+            [MarshalAs(UnmanagedType.LPStr)] string msg,
+            [MarshalAs(UnmanagedType.LPStr)] string eomorig,
+            [MarshalAs(UnmanagedType.LPStr)] string comp_dn,
+            StringBuilder exp_dn,
+            short length
+        );
+
+        [DllImport(LIBC, EntryPoint = "ns_rr_name")]
+        private static extern string NsRrName(
+            NsRr rr
+        );
+
+        [DllImport(LIBC, EntryPoint = "inet_ntoa")]
+        private static extern string InetNToA(
+            InAddr @in
+        );
+
+        public static IReadOnlyCollection<DnsRecord> QuerySrvRecord(
+            string query,
+            DnsRecordType type,
+            DnsQueryOptions options = DnsQueryOptions.BypassCache)
         {
-            NsRr rr;
-            if (NsParserr(&handle, NsSect.NsSAn, i, &rr) < 0)
-                throw new Exception("ns_parserr: TODO strerror");
+            var list = new List<DnsRecord>();
+            var buffer = new char[NS_PACKETSZ];
 
-            if (NsRrType(rr) != DnsRecordType.SRV) continue;
+            short respLen = -1;
+            if ((respLen = ResQuery(query, NsClass.NsCIn, type, buffer, NS_PACKETSZ)) < 0)
+                throw new Exception($"Query for {query} failed!");
 
-            var name = new StringBuilder(1025);
-            short ret;
-            if ((ret = DnExpand(NsMsgBase(handle),
-                    NsMsgEnd(handle),
-                    NsRrRdata(rr) + 6,
-                    name,
-                    1025)) < 0)
-                throw new Exception($"Failed to uncompress name ({ret})");
+            NsMsg handle;
+            if (NsInitParse(buffer, respLen, &handle) < 0)
+                throw new Exception("Failed to parse response buffer!");
 
-            Debug.WriteLine(name);
+            var count = NsMsgCount(handle, NsSect.NsSAn);
+            Debug.WriteLine($"{count} records returned in the answer section.");
 
-            var p = NsRrRdata(rr);
-            var ip = new InAddr
+            for (short i = 0; i < count; i++)
             {
-                s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
-            };
+                NsRr rr;
+                if (NsParserr(&handle, NsSect.NsSAn, i, &rr) < 0)
+                    throw new Exception("ns_parserr: TODO strerror");
 
-            list.Add(new DnsRecord
+                if (NsRrType(rr) != DnsRecordType.SRV) continue;
+
+                var name = new StringBuilder(1025);
+                short ret;
+                if ((ret = DnExpand(NsMsgBase(handle),
+                        NsMsgEnd(handle),
+                        NsRrRdata(rr) + 6,
+                        name,
+                        1025)) < 0)
+                    throw new Exception($"Failed to uncompress name ({ret})");
+
+                Debug.WriteLine(name);
+
+                var p = NsRrRdata(rr);
+                var ip = new InAddr
+                {
+                    s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
+                };
+
+                list.Add(new DnsRecord
+                {
+                    Target = InetNToA(ip),
+                    Name = rr.name.ToString(),
+                    //Port =
+                    //Priority =
+                    TimeToLive = (int) rr.ttl,
+                    Type = rr.type,
+                    //Weight = rr.
+                });
+            }
+
+            for (short i = 0; i < NsMsgCount(handle, NsSect.NsSAr); i++)
             {
-                Target = InetNToA(ip),
-                Name = rr.name.ToString(),
-                //Port =
-                //Priority =
-                TimeToLive = (int) rr.ttl,
-                Type = rr.type,
-                //Weight = rr.
-            });
+                NsRr rr;
+                if (NsParserr(&handle, NsSect.NsSAr, i, &rr) < 0)
+                    throw new Exception("ns_parserr: TODO strerror");
+
+                if (NsRrType(rr) != DnsRecordType.A) continue;
+
+                var p = NsRrRdata(rr);
+                var ip = new InAddr
+                {
+                    s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
+                };
+
+                Debug.WriteLine($"{NsRrName(rr)} has address {InetNToA(ip)}");
+
+                list.Add(new DnsRecord
+                {
+                    Type = rr.type,
+                    Name = rr.name.ToString(),
+                    Target = InetNToA(ip)
+                });
+            }
+
+            return list;
         }
 
-        for (short i = 0; i < NsMsgCount(handle, NsSect.NsSAr); i++)
+        private struct InAddr
         {
-            NsRr rr;
-            if(NsParserr(&handle, NsSect.NsSAr, i, &rr) < 0)
-                throw new Exception("ns_parserr: TODO strerror");
-
-            if (NsRrType(rr) != DnsRecordType.A) continue;
-
-            var p = NsRrRdata(rr);
-            var ip = new InAddr
-            {
-                s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
-            };
-
-            Debug.WriteLine($"{NsRrName(rr)} has address {InetNToA(ip)}");
-
-            list.Add(new DnsRecord
-            {
-                 Type = rr.type,
-                 Name = rr.name.ToString(),
-                 Target = InetNToA(ip)
-            });
+            public uint s_addr;
         }
 
-        return list;
-    }
+        private struct NsRr
+        {
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = NS_PACKETSZ)]
+            public char[] name;
+            public DnsRecordType type;
+            public ushort rr_class;
+            public uint ttl;
+            public ushort rdlength;
+            [MarshalAs(UnmanagedType.LPStr)]
+            public string rdata;
+        }
 
-    private struct InAddr
-    {
-        public uint s_addr;
-    }
+        private enum NsSect
+        {
+            NsSQd = 0, /*%< Query: Question. */
+            NsSZn = 0, /*%< Update: Zone. */
+            NsSAn = 1, /*%< Query: Answer. */
+            NsSPr = 1, /*%< Update: Prerequisites. */
+            NsSNs = 2, /*%< Query: Name servers. */
+            NsSUd = 2, /*%< Update: Update. */
+            NsSAr = 3, /*%< Query|Update: Additional records. */
+            NsSMax = 4
+        }
 
-    private struct NsRr
-    {
-        public char[] name = new char[NS_MAXDNAME];
-        public DnsRecordType type;
-        public ushort rr_class;
-        public uint ttl;
-        public ushort rdlength;
-        [MarshalAs(UnmanagedType.LPStr)] public string rdata;
+        private struct NsMsg
+        {
+            [MarshalAs(UnmanagedType.LPStr)] public string _msg, _eom;
+            public ushort _id, _flags;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int) NsSect.NsSMax)]
+            public ushort[] _counts;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int) NsSect.NsSMax)]
+            public string[] _sections;
+            public NsSect _sect;
+            public short _rrnum;
+            [MarshalAs(UnmanagedType.LPStr)]
+            public string _msg_ptr;
+        }
 
-        public NsRr() {}
-    }
-
-    private enum NsSect {
-        NsSQd = 0, /*%< Query: Question. */
-        NsSZn = 0, /*%< Update: Zone. */
-        NsSAn = 1, /*%< Query: Answer. */
-        NsSPr = 1, /*%< Update: Prerequisites. */
-        NsSNs = 2, /*%< Query: Name servers. */
-        NsSUd = 2, /*%< Update: Update. */
-        NsSAr = 3, /*%< Query|Update: Additional records. */
-        NsSMax = 4
-    }
-
-    private struct NsMsg
-    {
-        [MarshalAs(UnmanagedType.LPStr)] public string _msg, _eom;
-        public ushort _id, _flags;
-        public ushort[] _counts = new ushort[(int)NsSect.NsSMax];
-        [MarshalAs(UnmanagedType.ByValArray)] public string[] _sections = new string[(int)NsSect.NsSMax];
-        public NsSect _sect;
-        public short _rrnum;
-        [MarshalAs(UnmanagedType.LPStr)] public string _msg_ptr;
-
-        public NsMsg() {}
-    }
-
-    private enum NsClass : ushort
-    {
-        NsCInvalid,
-        NsCIn,
-        NsC2,
-        NsCChaos,
-        NsCHs,
-        NsCNone = 254,
-        NsCAny,
-        NsCMax = 65535
+        private enum NsClass : ushort
+        {
+            NsCInvalid,
+            NsCIn,
+            NsC2,
+            NsCChaos,
+            NsCHs,
+            NsCNone = 254,
+            NsCAny,
+            NsCMax = 65535
+        }
     }
 }

--- a/Kerberos.NET/Dns/DnsQueryPOSIX.cs
+++ b/Kerberos.NET/Dns/DnsQueryPOSIX.cs
@@ -1,0 +1,229 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Kerberos.NET.Dns;
+
+public unsafe class DnsQueryPOSIX
+{
+    private const int NS_PACKETSZ = 512;
+    private const int NS_MAXDNAME = 1025;
+
+    private const string LIBC = "libc.so";
+
+    [DllImport(LIBC, EntryPoint = "res_query")]
+    private static extern short ResQuery(
+        [MarshalAs(UnmanagedType.LPStr)] string dname,
+        NsClass @class,
+        DnsRecordType type,
+        char[] answer,
+        int anslen
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_initparse")]
+    private static extern short NsInitParse(
+        // [MarshalAs(UnmanagedType.LPStr)] string msg,
+        char[] msg,
+        short msglen,
+        NsMsg* handle
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_msg_count")]
+    private static extern ushort NsMsgCount(
+        NsMsg handle,
+        NsSect section
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_parserr")]
+    private static extern short NsParserr(
+        NsMsg* handle,
+        NsSect section,
+        short rrnum,
+        NsRr* rr
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_rr_type")]
+    private static extern DnsRecordType NsRrType(
+        NsRr rr
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_msg_base")]
+    private static extern string NsMsgBase(
+        NsMsg handle
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_msg_end")]
+    private static extern string NsMsgEnd(
+        NsMsg handle
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_rr_rdata")]
+    private static extern string NsRrRdata(
+        NsRr rr
+    );
+
+    [DllImport(LIBC, EntryPoint = "dn_expand")]
+    private static extern short DnExpand(
+        [MarshalAs(UnmanagedType.LPStr)] string msg,
+        [MarshalAs(UnmanagedType.LPStr)] string eomorig,
+        [MarshalAs(UnmanagedType.LPStr)] string comp_dn,
+        StringBuilder exp_dn,
+        short length
+    );
+
+    [DllImport(LIBC, EntryPoint = "ns_rr_name")]
+    private static extern string NsRrName(
+        NsRr rr
+    );
+
+    [DllImport(LIBC, EntryPoint = "inet_ntoa")]
+    private static extern string InetNToA(
+        InAddr @in
+    );
+
+    public static IReadOnlyCollection<DnsRecord> QuerySrvRecord(
+        string query,
+        DnsRecordType type,
+        DnsQueryOptions options = DnsQueryOptions.BypassCache)
+    {
+        var list = new List<DnsRecord>();
+        var buffer = new char[NS_PACKETSZ];
+
+        short respLen = -1;
+        if ((respLen = ResQuery(query, NsClass.NsCIn, type, buffer, NS_PACKETSZ)) < 0)
+            throw new Exception($"Query for {query} failed!");
+
+        NsMsg handle;
+        if (NsInitParse(buffer, respLen, &handle) < 0)
+            throw new Exception("Failed to parse response buffer!");
+
+        var count = NsMsgCount(handle, NsSect.NsSAn);
+        Debug.WriteLine($"{count} records returned in the answer section.");
+
+        for (short i = 0; i < count; i++)
+        {
+            NsRr rr;
+            if (NsParserr(&handle, NsSect.NsSAn, i, &rr) < 0)
+                throw new Exception("ns_parserr: TODO strerror");
+
+            if (NsRrType(rr) != DnsRecordType.SRV) continue;
+
+            var name = new StringBuilder(1025);
+            short ret;
+            if ((ret = DnExpand(NsMsgBase(handle),
+                    NsMsgEnd(handle),
+                    NsRrRdata(rr) + 6,
+                    name,
+                    1025)) < 0)
+                throw new Exception($"Failed to uncompress name ({ret})");
+
+            Debug.WriteLine(name);
+
+            var p = NsRrRdata(rr);
+            var ip = new InAddr
+            {
+                s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
+            };
+
+            list.Add(new DnsRecord
+            {
+                Target = InetNToA(ip),
+                Name = rr.name.ToString(),
+                //Port =
+                //Priority =
+                TimeToLive = (int) rr.ttl,
+                Type = rr.type,
+                //Weight = rr.
+            });
+        }
+
+        for (short i = 0; i < NsMsgCount(handle, NsSect.NsSAr); i++)
+        {
+            NsRr rr;
+            if(NsParserr(&handle, NsSect.NsSAr, i, &rr) < 0)
+                throw new Exception("ns_parserr: TODO strerror");
+
+            if (NsRrType(rr) != DnsRecordType.A) continue;
+
+            var p = NsRrRdata(rr);
+            var ip = new InAddr
+            {
+                s_addr = ((uint) p[3] << 24) | ((uint) p[2] << 16) | ((uint) p[1] << 8) | p[0]
+            };
+
+            Debug.WriteLine($"{NsRrName(rr)} has address {InetNToA(ip)}");
+
+            list.Add(new DnsRecord
+            {
+                 Type = rr.type,
+                 Name = rr.name.ToString(),
+                 Target = InetNToA(ip)
+            });
+        }
+
+        return list;
+    }
+
+    private struct InAddr
+    {
+        public uint s_addr;
+    }
+
+    private struct NsRr
+    {
+        public char[] name = new char[NS_MAXDNAME];
+        public DnsRecordType type;
+        public ushort rr_class;
+        public uint ttl;
+        public ushort rdlength;
+        [MarshalAs(UnmanagedType.LPStr)] public string rdata;
+
+        public NsRr() {}
+    }
+
+    private enum NsSect {
+        NsSQd = 0, /*%< Query: Question. */
+        NsSZn = 0, /*%< Update: Zone. */
+        NsSAn = 1, /*%< Query: Answer. */
+        NsSPr = 1, /*%< Update: Prerequisites. */
+        NsSNs = 2, /*%< Query: Name servers. */
+        NsSUd = 2, /*%< Update: Update. */
+        NsSAr = 3, /*%< Query|Update: Additional records. */
+        NsSMax = 4
+    }
+
+    private struct NsMsg
+    {
+        [MarshalAs(UnmanagedType.LPStr)] public string _msg, _eom;
+        public ushort _id, _flags;
+        public ushort[] _counts = new ushort[(int)NsSect.NsSMax];
+        [MarshalAs(UnmanagedType.ByValArray)] public string[] _sections = new string[(int)NsSect.NsSMax];
+        public NsSect _sect;
+        public short _rrnum;
+        [MarshalAs(UnmanagedType.LPStr)] public string _msg_ptr;
+
+        public NsMsg() {}
+    }
+
+    private enum NsClass : ushort
+    {
+        NsCInvalid,
+        NsCIn,
+        NsC2,
+        NsCChaos,
+        NsCHs,
+        NsCNone = 254,
+        NsCAny,
+        NsCMax = 65535
+    }
+}

--- a/Kerberos.NET/Dns/IKerberosDnsQuery.cs
+++ b/Kerberos.NET/Dns/IKerberosDnsQuery.cs
@@ -13,6 +13,8 @@ namespace Kerberos.NET.Dns
     /// </summary>
     public interface IKerberosDnsQuery
     {
+        public bool Debug { get; set; }
+
         /// <summary>
         /// Make a DNS lookup for the provided query and record type.
         /// </summary>

--- a/Kerberos.NET/Dns/POSIXDnsQuery.cs
+++ b/Kerberos.NET/Dns/POSIXDnsQuery.cs
@@ -1,0 +1,29 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kerberos.NET.Dns;
+
+public class POSIXDnsQuery : IKerberosDnsQuery
+{
+    public bool Debug { get; set; }
+
+    public bool IsSupported => OSPlatform.IsLinux;
+
+    public Task<IReadOnlyCollection<DnsRecord>> Query(string query, DnsRecordType type)
+    {
+        if (!IsSupported)
+        {
+            throw new InvalidOperationException("The POSIX DNS query implementation is not supported outside of POSIX-compliant systems");
+        }
+
+        var result = DnsQueryWin32.QuerySrvRecord(query, type);
+
+        return Task.FromResult(result);
+    }
+}

--- a/Kerberos.NET/Dns/POSIXDnsQuery.cs
+++ b/Kerberos.NET/Dns/POSIXDnsQuery.cs
@@ -7,23 +7,25 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Kerberos.NET.Dns;
-
-public class POSIXDnsQuery : IKerberosDnsQuery
+namespace Kerberos.NET.Dns
 {
-    public bool Debug { get; set; }
-
-    public bool IsSupported => OSPlatform.IsLinux;
-
-    public Task<IReadOnlyCollection<DnsRecord>> Query(string query, DnsRecordType type)
+    public class POSIXDnsQuery : IKerberosDnsQuery
     {
-        if (!IsSupported)
+        public bool Debug { get; set; }
+
+        public bool IsSupported => OSPlatform.IsLinux;
+
+        public Task<IReadOnlyCollection<DnsRecord>> Query(string query, DnsRecordType type)
         {
-            throw new InvalidOperationException("The POSIX DNS query implementation is not supported outside of POSIX-compliant systems");
+            if (!IsSupported)
+            {
+                throw new InvalidOperationException(
+                    "The POSIX DNS query implementation is not supported outside of POSIX-compliant systems");
+            }
+
+            var result = DnsQueryWin32.QuerySrvRecord(query, type);
+
+            return Task.FromResult(result);
         }
-
-        var result = DnsQueryWin32.QuerySrvRecord(query, type);
-
-        return Task.FromResult(result);
     }
 }

--- a/Kerberos.NET/Kerberos.NET.csproj
+++ b/Kerberos.NET/Kerberos.NET.csproj
@@ -5,6 +5,7 @@
     <Description>A cross-platform, managed-code Kerberos Ticket parsing, validation, and authentication library.</Description>
     <PackageTags>security kerberos</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Samples/KerbDumpCore/KerbDumpCore.csproj
+++ b/Samples/KerbDumpCore/KerbDumpCore.csproj
@@ -4,25 +4,27 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>KerbDumpCore</AssemblyName>
     <RootNamespace>KerbDump</RootNamespace>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <Compile Include="..\KerbDump\**\*.cs" />
     <EmbeddedResource Include="..\KerbDump\**\*.resx" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <Compile Remove="..\KerbDump\Properties\AssemblyInfo.cs" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <ProjectReference Include="..\..\Kerberos.NET\Kerberos.NET.csproj" />
   </ItemGroup>

--- a/Tests/Tests.Kerberos.NET/BaseTest.cs
+++ b/Tests/Tests.Kerberos.NET/BaseTest.cs
@@ -119,7 +119,7 @@ namespace Tests.Kerberos.NET
             "AFffP2PNqYn95dA4HD/On0QpOkNykZ3JBzSLnEr0+lo7bgZOTAF5m1IBwwEMdMhZRYudg4/MRPgKSzAx2cDfFfqe3c5a/e8IjYdZHI3fmQa1rPXn5XQ03aw9YJNkW1VNb0+n5JGR4Jge" +
             "C12oQyIh4DSu3XGvlXi+swg90=";
 
-        protected static readonly string BasePath = $"data{Path.DirectorySeparatorChar}";
+        protected static readonly string BasePath = $"Data{Path.DirectorySeparatorChar}";
 
         protected static byte[] ReadDataFile(string name)
         {

--- a/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
+++ b/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
@@ -10,6 +10,7 @@ using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -18,7 +19,7 @@ namespace Tests.Kerberos.NET
     [TestClass]
     public class Krb5CredentialCacheTests : BaseTest
     {
-        protected static string FilePath => $"{BasePath}cache\\krb5cc";
+        protected static string FilePath => Path.Combine(BasePath, "Cache", "krb5cc");
 
         [TestMethod]
         public void ParseFile()
@@ -34,7 +35,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void ParseFromBytes()
         {
-            var cacheBytes = ReadDataFile("cache\\krb5cc");
+            var cacheBytes = ReadDataFile(Path.Combine("Cache", "krb5cc"));
 
             using (var cache = new Krb5TicketCache(cacheBytes))
             {
@@ -61,7 +62,7 @@ namespace Tests.Kerberos.NET
 
                 var serialized = cache.Serialize();
 
-                var originalBytes = ReadDataFile("cache\\krb5cc");
+                var originalBytes = ReadDataFile(Path.Combine("Cache", "krb5cc"));
 
                 Assert.IsTrue(originalBytes.SequenceEqual(serialized));
             }

--- a/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
+++ b/Tests/Tests.Kerberos.NET/Configuration/Krb5ConfTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Kerberos.NET.Configuration;
@@ -250,7 +251,7 @@ namespace Tests.Kerberos.NET
 
         private static ConfigurationSectionList ParseConfiguration()
         {
-            var file = ReadDataFile("Configuration\\krb5.conf");
+            var file = ReadDataFile(Path.Combine("Configuration", "krb5.conf"));
 
             return Krb5ConfigurationSerializer.Deserialize(Encoding.Default.GetString(file));
         }

--- a/Tests/Tests.Kerberos.NET/Crypto/CryptoTests.cs
+++ b/Tests/Tests.Kerberos.NET/Crypto/CryptoTests.cs
@@ -104,6 +104,9 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void RC4Roundtrip()
         {
+            if(OSPlatform.IsLinux)
+                Assert.Inconclusive("MD4 operations are not supported by Linux");
+
             var data = new Memory<byte>(new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 });
 
             var key = CreateKey();

--- a/Tests/Tests.Kerberos.NET/Crypto/KeyTableTests.cs
+++ b/Tests/Tests.Kerberos.NET/Crypto/KeyTableTests.cs
@@ -169,6 +169,9 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public async Task Authenticator_SerializedKeytab()
         {
+            if(OSPlatform.IsLinux)
+                Assert.Inconclusive("MD4 operations are not supported by Linux");
+
             var key = new KerberosKey(
                 password: "P@ssw0rd!",
                 principalName: new PrincipalName(

--- a/Tests/Tests.Kerberos.NET/Dns/DnsTests.cs
+++ b/Tests/Tests.Kerberos.NET/Dns/DnsTests.cs
@@ -82,6 +82,8 @@ namespace Tests.Kerberos.NET
         {
             public bool WasCalled { get; set; }
 
+            public bool Debug { get; set; }
+
             public Task<IReadOnlyCollection<DnsRecord>> Query(string query, DnsRecordType type)
             {
                 this.WasCalled = true;

--- a/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/ClientToKdcE2ETests.cs
@@ -61,6 +61,9 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public async Task E2E_ClientWantsWeakCrypto_AllowWeak()
         {
+            if(OSPlatform.IsLinux)
+                Assert.Inconclusive("MD4 operations are not supported by Linux");
+
             var port = NextPort();
 
             using (var listener = StartListener(port, allowWeakCrypto: true))

--- a/Tests/Tests.Kerberos.NET/Messages/AllMessagesTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/AllMessagesTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
@@ -18,7 +19,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_AsRep()
         {
-            var file = ReadDataFile("messages\\as-rep");
+            var file = ReadDataFile(Path.Combine("Messages", "as-rep"));
 
             var decoded = TestSimpleRoundtrip(
                 "as-rep",
@@ -33,7 +34,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_AsReq()
         {
-            var file = ReadDataFile("messages\\as-req");
+            var file = ReadDataFile(Path.Combine("Messages", "as-req"));
 
             var decoded = TestSimpleRoundtrip(
                 "as-req",
@@ -48,7 +49,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_AsReqPreAuth()
         {
-            var file = ReadDataFile("messages\\as-req-preauth");
+            var file = ReadDataFile(Path.Combine("Messages", "as-req-preauth"));
 
             var decoded = TestSimpleRoundtrip(
                 "as-req-preauth",
@@ -63,7 +64,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_KrbErrorPreAuth()
         {
-            var file = ReadDataFile("messages\\krb-error-preauth-required");
+            var file = ReadDataFile(Path.Combine("Messages", "krb-error-preauth-required"));
 
             var decoded = TestSimpleRoundtrip(
                 "krb-error-preauth-required",
@@ -78,7 +79,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsRep()
         {
-            var file = ReadDataFile("messages\\tgs-rep-testuser-host-app03");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-rep-testuser-host-app03"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-rep-testuser-host-app03",
@@ -93,7 +94,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsRepKrbTgtRenew()
         {
-            var file = ReadDataFile("messages\\tgs-rep-testuser-krbtgt-renew");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-rep-testuser-krbtgt-renew"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-rep-testuser-krbtgt-renew",
@@ -108,7 +109,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsReq()
         {
-            var file = ReadDataFile("messages\\tgs-req-testuser-host-app03");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-req-testuser-host-app03"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-req-testuser-host-app03",
@@ -123,7 +124,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsReqKrbTgtRenew()
         {
-            var file = ReadDataFile("messages\\tgs-req-testuser-krbtgt-renew");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-req-testuser-krbtgt-renew"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-req-testuser-krbtgt-renew",
@@ -138,7 +139,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsReqS4uSelf()
         {
-            var file = ReadDataFile("messages\\tgs-req-app2-s4u-self");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-req-app2-s4u-self"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-req-app2-s4u-self",
@@ -153,7 +154,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsRepS4uSelf()
         {
-            var file = ReadDataFile("messages\\tgs-rep-app2-s4u-self");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-rep-app2-s4u-self"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-rep-app2-s4u-self",
@@ -168,7 +169,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsReqS4uProxy()
         {
-            var file = ReadDataFile("messages\\tgs-req-app2-s4u-proxy");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-req-app2-s4u-proxy"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-req-app2-s4u-proxy",
@@ -183,7 +184,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void Message_TgsRepS4uProxy()
         {
-            var file = ReadDataFile("messages\\tgs-rep-app2-s4u-proxy");
+            var file = ReadDataFile(Path.Combine("Messages", "tgs-rep-app2-s4u-proxy"));
 
             var decoded = TestSimpleRoundtrip(
                 "tgs-rep-app2-s4u-proxy",

--- a/Tests/Tests.Kerberos.NET/Messages/KdcReqTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KdcReqTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System.IO;
 using System.Linq;
 using Kerberos.NET.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,7 +16,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void ParseAsReq()
         {
-            var asReqBin = ReadDataFile("messages\\as-req").Skip(4).ToArray();
+            var asReqBin = ReadDataFile(Path.Combine("Messages", "as-req")).Skip(4).ToArray();
 
             var asreq = KrbAsReq.DecodeApplication(asReqBin);
 
@@ -29,7 +30,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void ParseAsReqWithPaData()
         {
-            var asReqBin = ReadDataFile("messages\\as-req-preauth").Skip(4).ToArray();
+            var asReqBin = ReadDataFile(Path.Combine("Messages", "as-req-preauth")).Skip(4).ToArray();
 
             var asreq = KrbAsReq.DecodeApplication(asReqBin);
 

--- a/Tests/Tests.Kerberos.NET/Messages/KrbAsReqTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbAsReqTests.cs
@@ -4,6 +4,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Kerberos.NET.Client;
@@ -34,7 +35,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void ParseAsReqApplicationMessage()
         {
-            var asReqBin = ReadDataFile("messages\\as-req").Skip(4).ToArray();
+            var asReqBin = ReadDataFile(Path.Combine("Messages", "as-req")).Skip(4).ToArray();
 
             var asReq = KrbAsReq.DecodeApplication(asReqBin);
 
@@ -49,7 +50,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void DecryptAsReqApplicationMessage()
         {
-            var asReqBin = ReadDataFile("messages\\as-req-preauth").Skip(4).ToArray();
+            var asReqBin = ReadDataFile(Path.Combine("Messages", "as-req-preauth")).Skip(4).ToArray();
 
             var asReq = KrbAsReq.DecodeApplication(asReqBin);
 

--- a/Tests/Tests.Kerberos.NET/Messages/KrbErrorTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbErrorTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
@@ -18,7 +19,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void ErrorPreAuthRoundtrip()
         {
-            var krbErrBin = ReadDataFile("messages\\krb-error-preauth-required").Skip(4).ToArray();
+            var krbErrBin = ReadDataFile(Path.Combine("Messages", "krb-error-preauth-required")).Skip(4).ToArray();
 
             var err = KrbError.DecodeApplication(krbErrBin);
 
@@ -30,7 +31,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void KrbErrorParseEtypeInfo()
         {
-            var krbErrBin = ReadDataFile("messages\\krb-error-preauth-required").Skip(4).ToArray();
+            var krbErrBin = ReadDataFile(Path.Combine("Messages", "krb-error-preauth-required")).Skip(4).ToArray();
 
             var err = KrbError.DecodeApplication(krbErrBin);
 

--- a/Tests/Tests.Kerberos.NET/Messages/KrbTgsReqTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbTgsReqTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System.IO;
 using System.Linq;
 using System.Security;
 using Kerberos.NET.Crypto;
@@ -23,7 +24,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void TgsParse()
         {
-            var tgsReqBytes = ReadDataFile("messages\\tgs-req-testuser-host-app03").Skip(4).ToArray();
+            var tgsReqBytes = ReadDataFile(Path.Combine("Messages", "tgs-req-testuser-host-app03")).Skip(4).ToArray();
 
             var tgsReq = KrbTgsReq.DecodeApplication(tgsReqBytes);
 
@@ -64,7 +65,7 @@ namespace Tests.Kerberos.NET
 
         private static void RetrieveS4u(out KrbTgsReq tgsReq, out KrbEncTicketPart krbtgt)
         {
-            var tgsReqBytes = ReadDataFile("messages\\tgs-req-app2-s4u-self").Skip(4).ToArray();
+            var tgsReqBytes = ReadDataFile(Path.Combine("Messages", "tgs-req-app2-s4u-self")).Skip(4).ToArray();
 
             tgsReq = KrbTgsReq.DecodeApplication(tgsReqBytes);
             Assert.IsNotNull(tgsReq);

--- a/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
@@ -4,6 +4,7 @@
 // -----------------------------------------------------------------------
 
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
@@ -43,7 +44,7 @@ namespace Tests.Kerberos.NET
             var krbtgtKey = new KerberosKey(key: Key, etype: EncryptionType.AES256_CTS_HMAC_SHA1_96);
             var longUserTermKey = new KerberosKey("P@ssw0rd!", salt: "CORP.IDENTITYINTERVENTION.COMtestuser");
 
-            var krbAsRepBytes = ReadDataFile("messages\\as-rep").Skip(4).ToArray();
+            var krbAsRepBytes = ReadDataFile(Path.Combine("Messages", "as-rep")).Skip(4).ToArray();
 
             var asRep = new KrbAsRep().DecodeAsApplication(krbAsRepBytes);
 

--- a/Tests/Tests.Kerberos.NET/Resources/ResourcesTest.cs
+++ b/Tests/Tests.Kerberos.NET/Resources/ResourcesTest.cs
@@ -4,6 +4,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using Kerberos.NET.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,7 +18,7 @@ namespace Tests.Kerberos.NET
         [ExpectedException(typeof(CryptographicException))]
         public void ResourceManagerFormattedResource()
         {
-            var asReq = ReadDataFile("messages\\as-req");
+            var asReq = ReadDataFile(Path.Combine("Messages", "as-req"));
 
             try
             {

--- a/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
+++ b/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
@@ -9,11 +9,9 @@
 
   <PropertyGroup>
     <DefineConstants>WEAKCRYPTO</DefineConstants>
+    <DefineConstants Condition="'$(Platform)' == 'x64'">X64</DefineConstants>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('Windows'))">WINDOWS</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Platform)' == 'x64'">
-    <DefineConstants>X64</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Tests/Tests.Kerberos.NET/Win32/LsaInteropTests.cs
+++ b/Tests/Tests.Kerberos.NET/Win32/LsaInteropTests.cs
@@ -18,6 +18,7 @@ namespace Tests.Kerberos.NET
     [TestClass]
     public class LsaInteropTests
     {
+#if WINDOWS
         private const string RequestedSpn = "host/test.com";
 
         private static readonly KerberosKey Key = new KerberosKey(key: new byte[16], etype: EncryptionType.AES128_CTS_HMAC_SHA1_96);
@@ -163,5 +164,6 @@ namespace Tests.Kerberos.NET
                 Assert.AreEqual("test.com", decryptedToken.Ticket.CRealm);
             }
         }
+#endif
     }
 }

--- a/Tests/Tests.Kerberos.NET/Win32/SspiTests.cs
+++ b/Tests/Tests.Kerberos.NET/Win32/SspiTests.cs
@@ -14,6 +14,7 @@ namespace Tests.Kerberos.NET
     [TestClass]
     public class SspiTests
     {
+#if WINDOWS
         [TestMethod]
         public void TryGettingSspiTicketTest()
         {
@@ -48,5 +49,6 @@ namespace Tests.Kerberos.NET
                 Assert.IsTrue(KerberosCryptoTransformer.AreEqualSlow(contextSender.SessionKey, contextReceiver.SessionKey));
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
### What's the problem?

Kerberos.NET doesn't include "autodiscovery" of the KDC on a Linux host. Therefore one must "rely completely on a krb5 configuration file to provide all the necessary records, but that's complicated and messy." (qouted from [here](https://github.com/dotnet/Kerberos.NET/issues/185#issue-684211547))

### What's the solution?

I've implemented a native approach using `resolv.h` and friends in `libc`. I basically ported code written by Gerald Carter. Sadly, I don't have the original link to the gist anymore.

### What issue is this related to, if any?

#185 
