### PR TITLE
Bugfix/lsa cache expiry

### DIFF
--- a/Kerberos.NET/Cache/TicketCacheBase.cs
+++ b/Kerberos.NET/Cache/TicketCacheBase.cs
@@ -75,7 +75,7 @@ namespace Kerberos.NET
 
             if (LsaCacheTypes.Any(c => c.Equals(cachePath, StringComparison.OrdinalIgnoreCase)))
             {
-                cacheType = "mslsa";
+                cacheType = "MSLSA";
                 return true;
             }
 

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -749,32 +749,14 @@ namespace Kerberos.NET.Client
 
         private bool TryFindRealmHint(RequestServiceTicket rst, out string referral)
         {
-            foreach (var kv in this.Configuration.DomainRealm)
-            {
-                //
-                // .foo.net matches anything under foo.net
-                //      bar.foo.net matches
-                //      baz.foo.net matches
-                //      baz.bar.foo.net matches
-                //      foo.net does not match
-                //      bar.net does not match
-                //
-                // bar.foo.net matches explicitly
-                //      bar.foo.net matches
-                //      baz.foo.net does not match
-                //      baz.bar.foo.net does not match
-                //      foo.net does not match
-                //
+            var spn = rst.ServicePrincipalName;
 
-                if ((kv.Key[0] == '.' && rst.ServicePrincipalName.EndsWith(kv.Key, StringComparison.OrdinalIgnoreCase)) ||
-                    (string.Equals(kv.Key, rst.ServicePrincipalName, StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    referral = $"krbtgt/{kv.Value.ToUpperInvariant()}";
-                    return true;
-                }
+            if (this.Configuration.TryFindRealmHint(spn, out referral))
+            {
+                referral = $"krbtgt/{referral}";
+                return true;
             }
 
-            referral = null;
             return false;
         }
 


### PR DESCRIPTION
### What's the problem?

Auth Package calls don't handle expired tickets due to the nature of where the auth package exposes the get-ticket functionality. This is further complicated by the fact that cross-realm tickets don't get resolved completely if there isn't enough of a name hint.

- [X] Bugfix
- [X] New Feature

### What's the solution?

Purge the cache to trigger the SPN lookup.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Fixes #326
