### PR TITLE
Handle zero length krb5cc headers

### DIFF
--- a/Kerberos.NET/Cache/Krb5CredentialCache.cs
+++ b/Kerberos.NET/Cache/Krb5CredentialCache.cs
@@ -581,25 +581,22 @@ namespace Kerberos.NET.Client
         {
             var headerLength = buffer.ReadInt16BigEndian();
 
-            int headerRead = 0;
-
-            do
+            while (headerLength > 0)
             {
                 var tag = (Krb5CredentialCacheTag)buffer.ReadInt16BigEndian();
+                headerLength -= sizeof(short);
+
                 var length = buffer.ReadInt16BigEndian();
+                headerLength -= sizeof(short);
+
                 var value = buffer.ReadMemory(length);
+                headerLength -= length;
 
                 this.Header[tag] = value;
-
-                headerRead += 4 + length;
             }
-            while (headerRead < headerLength);
         }
 
-        private static int GetEpoch(DateTimeOffset dt)
-        {
-            return dt == DateTimeOffset.MinValue ? 0 : (int)dt.ToUnixTimeSeconds();
-        }
+        private static int GetEpoch(DateTimeOffset dt) => dt == DateTimeOffset.MinValue ? 0 : (int)dt.ToUnixTimeSeconds();
 
         [DebuggerDisplay("{Client} {Server}")]
         public class Krb5Credential

--- a/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
+++ b/Tests/Tests.Kerberos.NET/Client/Krb5CredentialCacheTests.cs
@@ -44,6 +44,31 @@ namespace Tests.Kerberos.NET
             }
         }
 
+        [TestMethod]
+        public void RoundtripZeroLengthHeader()
+        {
+            var cacheBytes = ReadDataFile("cache\\krb5cc");
+            Assert.IsNotNull(cacheBytes);
+
+            using (var cache = new Krb5TicketCache(cacheBytes))
+            {
+                Assert.AreEqual(1, cache.Krb5Cache.Header.Count);
+
+                cache.Krb5Cache.Header.Clear();
+
+                AssertCacheFile(cache);
+
+                cacheBytes = cache.Serialize();
+            }
+
+            using (var cache = new Krb5TicketCache(cacheBytes))
+            {
+                AssertCacheFile(cache);
+
+                Assert.AreEqual(0, cache.Krb5Cache.Header.Count);
+            }
+        }
+
         private static void AssertCacheFile(Krb5TicketCache cache)
         {
             var ticket = cache.GetCacheItem<KerberosClientCacheEntry>("krbtgt/IPA.IDENTITYINTERVENTION.COM");


### PR DESCRIPTION
### What's the problem?

Krb5cc headers can be empty and we fail to parse that because we assume there's always a value.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Rework the `do`/`while` into a regular `while` loop so that it immediately exits on a zero length.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

N/A Internally reported.