### PR TITLE
Made the `ClaimEntry.Id` property's setter public

### DIFF
--- a/Kerberos.NET/Entities/Pac/ClaimEntry.cs
+++ b/Kerberos.NET/Entities/Pac/ClaimEntry.cs
@@ -38,7 +38,7 @@ namespace Kerberos.NET.Entities.Pac
             buffer.WriteDeferredStructUnion(this);
         }
 
-        public string Id { get; private set; }
+        public string Id { get; set; }
 
         public ClaimType Type { get; set; }
 


### PR DESCRIPTION
### What's the problem?

The existing setter is private and does not allow external modifications.

- [ ] Bugfix
- [ ] New Feature

### What's the solution?

Made the setter public.

 - [ ] Includes unit tests
 - [x] Requires manual test

### What issue is this related to, if any?

This PR is related to issue #353 
