### PR TITLE
Implement KRBPASSWD according to RFC 3244.

### DIFF
--- a/Kerberos.NET/Client/Transport/IKerberosTransport.cs
+++ b/Kerberos.NET/Client/Transport/IKerberosTransport.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Kerberos.NET.Asn1;
 using Kerberos.NET.Configuration;
+using Kerberos.NET.Entities.ChangePassword;
 
 namespace Kerberos.NET.Transport
 {
@@ -42,5 +43,26 @@ namespace Kerberos.NET.Transport
             CancellationToken cancellation = default
         )
             where T : IAsn1ApplicationEncoder<T>, new();
+    }
+
+    public interface IKerberosTransport2: IKerberosTransport
+    {
+        Task<ReadOnlyMemory<byte>> SendMessage(
+            string domain,
+            ReadOnlyMemory<byte> req,
+            CancellationToken cancellation = default
+        );
+
+        Task<KrbChangePasswdRep> SendMessageChangePassword(
+            string domain,
+            KrbChangePasswdReq msg,
+            CancellationToken cancellation = default
+        );
+
+        Task<ReadOnlyMemory<byte>> SendMessageChangePassword(
+            string domain,
+            ReadOnlyMemory<byte> req,
+            CancellationToken cancellation = default
+        );
     }
 }

--- a/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdData.generated.cs
+++ b/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdData.generated.cs
@@ -1,0 +1,179 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+// This is a generated file.
+// The generation template has been modified from .NET Runtime implementation
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Asn1;
+using Kerberos.NET.Crypto;
+using Kerberos.NET.Asn1;
+
+namespace Kerberos.NET.Entities
+{
+    public partial class KrbChangePasswdData
+    {
+        /*
+		  ChangePasswdData ::=  SEQUENCE {
+                 newpasswd   [0] OCTET STRING,
+                 targname    [1] PrincipalName OPTIONAL,
+                 targrealm   [2] Realm OPTIONAL
+          }
+         */
+    
+        public ReadOnlyMemory<byte> NewPasswd { get; set; }
+  
+        public KrbPrincipalName TargName { get; set; }
+  
+        public string TargRealm { get; set; }
+  
+        // Encoding methods
+        public ReadOnlyMemory<byte> Encode()
+        {
+            var writer = new AsnWriter(AsnEncodingRules.DER);
+
+            Encode(writer);
+
+            return writer.EncodeAsMemory();
+        }
+ 
+        internal void Encode(AsnWriter writer)
+        {
+            Encode(writer, Asn1Tag.Sequence);
+        }
+        
+        internal void Encode(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            writer.WriteOctetString(NewPasswd.Span);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            if (Asn1Extension.HasValue(TargName))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+                TargName?.Encode(writer);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+            }
+
+            if (Asn1Extension.HasValue(TargRealm))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
+                writer.WriteCharacterString(UniversalTagNumber.GeneralString, TargRealm);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
+            }
+  
+            writer.PopSequence(tag);
+        }
+        
+        internal void EncodeApplication(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            this.Encode(writer, Asn1Tag.Sequence);
+            
+            writer.PopSequence(tag);
+        }       
+        
+        public virtual ReadOnlyMemory<byte> EncodeApplication() => new ReadOnlyMemory<byte>();
+         
+        internal ReadOnlyMemory<byte> EncodeApplication(Asn1Tag tag)
+        {
+            using (var writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                EncodeApplication(writer, tag);
+
+                return writer.EncodeAsMemory();
+            }
+        }
+        
+        public static KrbChangePasswdData Decode(ReadOnlyMemory<byte> data)
+        {
+            return Decode(data, AsnEncodingRules.DER);
+        }
+
+        internal static KrbChangePasswdData Decode(ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
+        }
+        
+        internal static KrbChangePasswdData Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded)
+        {
+            AsnReader reader = new AsnReader(encoded, AsnEncodingRules.DER);
+            
+            Decode(reader, expectedTag, out KrbChangePasswdData decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static KrbChangePasswdData Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, expectedTag, out KrbChangePasswdData decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static void Decode<T>(AsnReader reader, out T decoded)
+          where T: KrbChangePasswdData, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+            
+            Decode(reader, Asn1Tag.Sequence, out decoded);
+        }
+
+        internal static void Decode<T>(AsnReader reader, Asn1Tag expectedTag, out T decoded)
+          where T: KrbChangePasswdData, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            decoded = new T();
+            
+            AsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            AsnReader explicitReader;
+            
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            if (explicitReader.TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory<byte> tmpNewPasswd))
+            {
+                decoded.NewPasswd = tmpNewPasswd;
+            }
+            else
+            {
+                decoded.NewPasswd = explicitReader.ReadOctetString();
+            }
+
+            explicitReader.ThrowIfNotEmpty();
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 1)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 1));                
+            
+                KrbPrincipalName.Decode<KrbPrincipalName>(explicitReader, out KrbPrincipalName tmpTargName);
+                decoded.TargName = tmpTargName;
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 2)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 2));                
+            
+                decoded.TargRealm = explicitReader.ReadCharacterString(UniversalTagNumber.GeneralString);
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            sequenceReader.ThrowIfNotEmpty();
+        }
+    }
+}

--- a/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdData.xml
+++ b/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdData.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<asn:Sequence
+  xmlns:asn="http://schemas.dot.net/asnxml/201808/"
+  name="KrbChangePasswdData"
+  namespace="Kerberos.NET.Entities">
+  <!--
+		  ChangePasswdData ::=  SEQUENCE {
+                 newpasswd   [0] OCTET STRING,
+                 targname    [1] PrincipalName OPTIONAL,
+                 targrealm   [2] Realm OPTIONAL
+          }-->
+
+  <asn:OctetString name="NewPasswd" explicitTag="0" />
+  <asn:AsnType name="TargName" explicitTag="1" typeName="KrbPrincipalName" optional="true" />
+  <asn:GeneralString name="TargRealm" explicitTag="2" optional="true" />
+
+</asn:Sequence>

--- a/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdReq.cs
+++ b/Kerberos.NET/Entities/ChangePassword/KrbChangePasswdReq.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Buffers.Binary;
+
+namespace Kerberos.NET.Entities.ChangePassword
+{
+    public class KrbChangePasswdReq
+    {
+        /*
+         *       0                   1                   2                   3
+         *       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      |         message length        |    protocol version number    |
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      |          AP_REQ length        |         AP-REQ data           /
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      /                         KRB-PRIV message                      /
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+
+        public KrbApReq ApReq { get; set; }
+        public KrbPriv KrbPriv { get; set; }
+
+        public KrbChangePasswdReq()
+        {
+
+        }
+        
+        public ReadOnlyMemory<byte> Encode()
+        {
+            var apReqBytes = ApReq.EncodeApplication();
+            var krbPrivBytes = KrbPriv.EncodeApplication();
+
+            /*
+             *  0                   1                   2                   3
+             *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+             *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+             *  |         message length        |    protocol version number    |
+             *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+             *  |          AP_REQ length        |         AP_REQ data           /
+             *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+             *  /                        KRB-PRIV message                       /
+             *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+             */
+
+            // message length
+            short messageLength = (short)(apReqBytes.Length + krbPrivBytes.Length + 6);
+
+            var message = new Span<byte>(new byte[messageLength]);
+
+            BinaryPrimitives.WriteInt16BigEndian(message.Slice(0, 2), messageLength);
+            BinaryPrimitives.WriteInt16BigEndian(message.Slice(2, 2), -128); // version
+            BinaryPrimitives.WriteInt16BigEndian(message.Slice(4, 2), (short)apReqBytes.Length);
+            apReqBytes.Span.CopyTo(message.Slice(6, apReqBytes.Length));
+            krbPrivBytes.Span.CopyTo(message.Slice(6 + apReqBytes.Length, krbPrivBytes.Length));
+
+            return message.ToArray();
+        }
+               
+
+    }
+
+
+}

--- a/Kerberos.NET/Entities/ChangePassword/KrbChangePasswordRep.cs
+++ b/Kerberos.NET/Entities/ChangePassword/KrbChangePasswordRep.cs
@@ -1,0 +1,102 @@
+﻿using Kerberos.NET.Crypto;
+using System;
+using System.Buffers.Binary;
+using System.IO;
+
+namespace Kerberos.NET.Entities.ChangePassword
+{
+    public class KrbChangePasswdRep
+    {
+        /*
+         *       0                   1                   2                   3
+         *       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      |         message length        |    protocol version number    |
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      |          AP_REP length        |         AP-REP data           /
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *      /                         KRB-PRIV message                      /
+         *      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+
+        /* UserData of KRB-PRIV:
+         *   0                   1                   2                   3
+         *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+         *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         *  |          result code          |        result string          /
+         *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        */
+
+        public KrbApRep ApRep { get; private set; }
+
+        public KrbPriv KrbPriv { get; private set; }
+
+        public KrbEncKrbPrivPart encKrbPriv { get; private set; }
+
+        public enum StatusCode
+        {
+            KRB5_KPASSWD_SUCCESS = 0,             // request succeeds (This value is not allowed in a KRB-ERROR message)
+            KRB5_KPASSWD_MALFORMED = 1,           // request fails due to being malformed
+            KRB5_KPASSWD_HARDERROR = 2,           // request fails due to "hard" error in processing the request(for example, there is a resource or other problem causing the request to fail)
+            KRB5_KPASSWD_AUTHERROR = 3,           // request fails due to an error in authentication processing
+            KRB5_KPASSWD_SOFTERROR = 4,           // request fails due to a "soft" error in processing the request
+            KRB5_KPASSWD_ACCESSDENIED = 5,        // requestor not authorized
+            KRB5_KPASSWD_BAD_VERSION = 6,         // protocol version unsupported
+            KRB5_KPASSWD_INITIAL_FLAG_NEEDED = 7, // initial flag required
+            KRB5_KPASSWD_OTHER = 0xFFFF           // returned if the request fails for some other reason.
+        };
+
+        public KrbChangePasswdRep(ReadOnlyMemory<byte> data)
+        {
+            Decode(data);
+        }
+
+        private void Decode(ReadOnlyMemory<byte> data)
+        {
+            if (data.Length < 6)
+            {
+                throw new InvalidDataException("KrbChangePassword message too short");
+            }
+
+            short messageLength = BinaryPrimitives.ReadInt16BigEndian(data.Span.Slice(0, 2));
+            if (data.Length < messageLength)
+            {
+                throw new InvalidDataException("KrbChangePassword message shorter than message length header says");
+            }
+
+            short version = BinaryPrimitives.ReadInt16BigEndian(data.Span.Slice(2, 2));
+            if (version != 1)
+            {
+                throw new InvalidDataException("KrbChangePassword bad version in reply");
+            }
+
+            short apRepLength = BinaryPrimitives.ReadInt16BigEndian(data.Span.Slice(4, 2));
+            if (apRepLength + 6 > messageLength)
+            {
+                throw new InvalidDataException("KrbChangePassword apRepLength too long");
+            }
+
+            ApRep = KrbApRep.DecodeApplication(data.Span.Slice(6, apRepLength).ToArray());
+
+            short krbPrivLength = (short)(messageLength - apRepLength - 6);
+            if (krbPrivLength <= 2) // krbPriv is ASN encoded
+            {
+                throw new InvalidDataException("KrbChangePassword krbPriv remaining length too short");
+            }
+
+            KrbPriv = KrbPriv.DecodeApplication(data.Span.Slice(6 + apRepLength, krbPrivLength).ToArray());
+        }
+
+        public void Decrypt(KerberosKey key)
+        {           
+            encKrbPriv = KrbPriv.EncPart.Decrypt(
+                key,
+                KeyUsage.EncKrbPrivPart,
+                d => KrbEncKrbPrivPart.DecodeApplication(d)
+            );
+        }
+
+    }
+
+
+}

--- a/Kerberos.NET/Entities/Krb/KrbEncKrbPrivPart.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbEncKrbPrivPart.generated.cs
@@ -1,0 +1,256 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+// This is a generated file.
+// The generation template has been modified from .NET Runtime implementation
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Asn1;
+using Kerberos.NET.Crypto;
+using Kerberos.NET.Asn1;
+
+namespace Kerberos.NET.Entities
+{
+    public partial class KrbEncKrbPrivPart
+    {
+        /*
+		  EncKrbPrivPart  ::= [APPLICATION 28] SEQUENCE {
+				  user-data       [0] OCTET STRING,
+				  timestamp       [1] KerberosTime OPTIONAL,
+				  usec            [2] Microseconds OPTIONAL,
+				  seq-number      [3] UInt32 OPTIONAL,
+				  s-address       [4] HostAddress ( sender's addr ),
+				  r-address       [5] HostAddress OPTIONAL ( recip's addr )
+          }
+         */
+    
+        public ReadOnlyMemory<byte> UserData { get; set; }
+  
+        public DateTimeOffset? Timestamp { get; set; }
+  
+        public int? Usec { get; set; }
+  
+        public int? SeqNumber { get; set; }
+  
+        public KrbHostAddress SAddress { get; set; }
+  
+        public KrbHostAddress RAddress { get; set; }
+  
+        // Encoding methods
+        internal void Encode(AsnWriter writer)
+        {
+            EncodeApplication(writer, ApplicationTag);
+        }
+        
+        internal void Encode(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            writer.WriteOctetString(UserData.Span);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            if (Asn1Extension.HasValue(Timestamp))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+                writer.WriteGeneralizedTime(Timestamp.Value);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+            }
+
+            if (Asn1Extension.HasValue(Usec))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
+                writer.WriteInteger(Usec.Value);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
+            }
+
+            if (Asn1Extension.HasValue(SeqNumber))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+                writer.WriteInteger(SeqNumber.Value);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+            }
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 4));
+            SAddress?.Encode(writer);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 4));
+
+            if (Asn1Extension.HasValue(RAddress))
+            {
+                writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
+                RAddress?.Encode(writer);
+                writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
+            }
+            writer.PopSequence(tag);
+        }
+        
+        internal void EncodeApplication(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            this.Encode(writer, Asn1Tag.Sequence);
+            
+            writer.PopSequence(tag);
+        }       
+        
+        private static readonly Asn1Tag ApplicationTag = new Asn1Tag(TagClass.Application, 28);
+        
+        public virtual ReadOnlyMemory<byte> EncodeApplication() 
+        {
+          return EncodeApplication(ApplicationTag);
+        }
+        
+        public static KrbEncKrbPrivPart DecodeApplication(ReadOnlyMemory<byte> encoded)
+        {
+            AsnReader reader = new AsnReader(encoded, AsnEncodingRules.DER);
+
+            var sequence = reader.ReadSequence(ApplicationTag);
+          
+            KrbEncKrbPrivPart decoded;
+            Decode(sequence, Asn1Tag.Sequence, out decoded);
+            sequence.ThrowIfNotEmpty();
+
+            reader.ThrowIfNotEmpty();
+
+            return decoded;
+        }
+        
+        internal static KrbEncKrbPrivPart DecodeApplication<T>(AsnReader reader, out T decoded)
+          where T: KrbEncKrbPrivPart, new()
+        {
+            var sequence = reader.ReadSequence(ApplicationTag);
+          
+            Decode(sequence, Asn1Tag.Sequence, out decoded);
+            sequence.ThrowIfNotEmpty();
+
+            reader.ThrowIfNotEmpty();
+
+            return decoded;
+        }
+         
+        internal ReadOnlyMemory<byte> EncodeApplication(Asn1Tag tag)
+        {
+            using (var writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                EncodeApplication(writer, tag);
+
+                return writer.EncodeAsMemory();
+            }
+        }
+        
+        internal static KrbEncKrbPrivPart Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded)
+        {
+            AsnReader reader = new AsnReader(encoded, AsnEncodingRules.DER);
+            
+            Decode(reader, expectedTag, out KrbEncKrbPrivPart decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static KrbEncKrbPrivPart Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, expectedTag, out KrbEncKrbPrivPart decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static void Decode<T>(AsnReader reader, out T decoded)
+          where T: KrbEncKrbPrivPart, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+            
+            DecodeApplication(reader, out decoded);
+        }
+
+        internal static void Decode<T>(AsnReader reader, Asn1Tag expectedTag, out T decoded)
+          where T: KrbEncKrbPrivPart, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            decoded = new T();
+            
+            AsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            AsnReader explicitReader;
+            
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            if (explicitReader.TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory<byte> tmpUserData))
+            {
+                decoded.UserData = tmpUserData;
+            }
+            else
+            {
+                decoded.UserData = explicitReader.ReadOctetString();
+            }
+
+            explicitReader.ThrowIfNotEmpty();
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 1)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 1));                
+            
+                decoded.Timestamp = explicitReader.ReadGeneralizedTime();
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 2)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 2));                
+            
+                if (explicitReader.TryReadInt32(out int tmpUsec))
+                {
+                    decoded.Usec = tmpUsec;
+                }
+                else
+                {
+                    explicitReader.ThrowIfNotEmpty();
+                }
+
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 3)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 3));                
+            
+                if (explicitReader.TryReadInt32(out int tmpSeqNumber))
+                {
+                    decoded.SeqNumber = tmpSeqNumber;
+                }
+                else
+                {
+                    explicitReader.ThrowIfNotEmpty();
+                }
+
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 4));
+            KrbHostAddress.Decode<KrbHostAddress>(explicitReader, out KrbHostAddress tmpSAddress);
+            decoded.SAddress = tmpSAddress;
+
+            explicitReader.ThrowIfNotEmpty();
+
+            if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 5)))
+            {
+                explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 5));                
+            
+                KrbHostAddress.Decode<KrbHostAddress>(explicitReader, out KrbHostAddress tmpRAddress);
+                decoded.RAddress = tmpRAddress;
+                explicitReader.ThrowIfNotEmpty();
+            }
+
+            sequenceReader.ThrowIfNotEmpty();
+        }
+    }
+}

--- a/Kerberos.NET/Entities/Krb/KrbEncKrbPrivPart.xml
+++ b/Kerberos.NET/Entities/Krb/KrbEncKrbPrivPart.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<asn:Sequence
+  xmlns:asn="http://schemas.dot.net/asnxml/201808/"
+  name="KrbEncKrbPrivPart"
+  namespace="Kerberos.NET.Entities" explicitTag="28">
+  <!--
+		  EncKrbPrivPart  ::= [APPLICATION 28] SEQUENCE {
+				  user-data       [0] OCTET STRING,
+				  timestamp       [1] KerberosTime OPTIONAL,
+				  usec            [2] Microseconds OPTIONAL,
+				  seq-number      [3] UInt32 OPTIONAL,
+				  s-address       [4] HostAddress ( sender's addr ),
+				  r-address       [5] HostAddress OPTIONAL ( recip's addr )
+          }-->
+
+  <asn:OctetString name="UserData" explicitTag="0" />
+  <asn:GeneralizedTime name="Timestamp" explicitTag="1" optional="true" />
+  <asn:Integer name="Usec" explicitTag="2" backingType="int" optional="true" />
+  <asn:Integer name="SeqNumber" explicitTag="3" backingType="int" optional="true" />
+  <asn:AsnType name="SAddress" explicitTag="4" typeName="KrbHostAddress" />
+  <asn:AsnType name="RAddress" explicitTag="5" typeName="KrbHostAddress" optional="true" />
+  
+</asn:Sequence>

--- a/Kerberos.NET/Entities/Krb/KrbError.cs
+++ b/Kerberos.NET/Entities/Krb/KrbError.cs
@@ -24,11 +24,18 @@ namespace Kerberos.NET.Entities
 
         public static bool CanDecode(ReadOnlyMemory<byte> encoded)
         {
-            var reader = new AsnReader(encoded, AsnEncodingRules.DER);
+            try
+            {
+                var reader = new AsnReader(encoded, AsnEncodingRules.DER);
 
-            var tag = reader.ReadTagAndLength(out _, out _);
+                var tag = reader.ReadTagAndLength(out _, out _);
 
-            return tag.HasSameClassAndValue(KrbErrorTag);
+                return tag.HasSameClassAndValue(KrbErrorTag);
+            }
+            catch (System.Security.Cryptography.CryptographicException)
+            {
+                return false;
+            }
         }
 
         public void StampServerTime()

--- a/Kerberos.NET/Entities/Krb/KrbPriv.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPriv.cs
@@ -1,0 +1,20 @@
+﻿using Kerberos.NET.Crypto;
+
+namespace Kerberos.NET.Entities
+{
+    public partial class KrbPriv
+    {
+        public static KrbPriv Create(KerberosKey key, KrbEncKrbPrivPart krbPrivEncPartUnencrypted)
+        {
+            return new KrbPriv
+            {
+                ProtocolVersionNumber = 5,
+                MessageType = MessageType.KRB_PRIV,
+                EncPart = KrbEncryptedData.Encrypt(
+                            data: krbPrivEncPartUnencrypted.EncodeApplication(),
+                            key: key,
+                            usage: KeyUsage.EncKrbPrivPart)
+            };
+        }
+    }
+}

--- a/Kerberos.NET/Entities/Krb/KrbPriv.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbPriv.generated.cs
@@ -1,0 +1,184 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+// This is a generated file.
+// The generation template has been modified from .NET Runtime implementation
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Asn1;
+using Kerberos.NET.Crypto;
+using Kerberos.NET.Asn1;
+
+namespace Kerberos.NET.Entities
+{
+    public partial class KrbPriv
+    {
+        /*
+		  KRB-PRIV        ::= [APPLICATION 21] SEQUENCE {
+			  pvno            [0] INTEGER (5),
+			  msg-type        [1] INTEGER (21),
+              // NOTE: there is no [2] tag
+			  enc-part        [3] EncryptedData // EncKrbPrivPart 
+
+          }
+         */
+    
+        public int ProtocolVersionNumber { get; set; }
+  
+        public MessageType MessageType { get; set; }
+    
+        public KrbEncryptedData EncPart { get; set; }
+  
+        // Encoding methods
+        internal void Encode(AsnWriter writer)
+        {
+            EncodeApplication(writer, ApplicationTag);
+        }
+        
+        internal void Encode(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            writer.WriteInteger(ProtocolVersionNumber);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+            writer.WriteInteger((long)MessageType);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+            EncPart?.Encode(writer);
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+            writer.PopSequence(tag);
+        }
+        
+        internal void EncodeApplication(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+            
+            this.Encode(writer, Asn1Tag.Sequence);
+            
+            writer.PopSequence(tag);
+        }       
+        
+        private static readonly Asn1Tag ApplicationTag = new Asn1Tag(TagClass.Application, 21);
+        
+        public virtual ReadOnlyMemory<byte> EncodeApplication() 
+        {
+          return EncodeApplication(ApplicationTag);
+        }
+        
+        public static KrbPriv DecodeApplication(ReadOnlyMemory<byte> encoded)
+        {
+            AsnReader reader = new AsnReader(encoded, AsnEncodingRules.DER);
+
+            var sequence = reader.ReadSequence(ApplicationTag);
+          
+            KrbPriv decoded;
+            Decode(sequence, Asn1Tag.Sequence, out decoded);
+            sequence.ThrowIfNotEmpty();
+
+            reader.ThrowIfNotEmpty();
+
+            return decoded;
+        }
+        
+        internal static KrbPriv DecodeApplication<T>(AsnReader reader, out T decoded)
+          where T: KrbPriv, new()
+        {
+            var sequence = reader.ReadSequence(ApplicationTag);
+          
+            Decode(sequence, Asn1Tag.Sequence, out decoded);
+            sequence.ThrowIfNotEmpty();
+
+            reader.ThrowIfNotEmpty();
+
+            return decoded;
+        }
+         
+        internal ReadOnlyMemory<byte> EncodeApplication(Asn1Tag tag)
+        {
+            using (var writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                EncodeApplication(writer, tag);
+
+                return writer.EncodeAsMemory();
+            }
+        }
+        
+        internal static KrbPriv Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded)
+        {
+            AsnReader reader = new AsnReader(encoded, AsnEncodingRules.DER);
+            
+            Decode(reader, expectedTag, out KrbPriv decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static KrbPriv Decode(Asn1Tag expectedTag, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
+        {
+            AsnReader reader = new AsnReader(encoded, ruleSet);
+            
+            Decode(reader, expectedTag, out KrbPriv decoded);
+            reader.ThrowIfNotEmpty();
+            return decoded;
+        }
+
+        internal static void Decode<T>(AsnReader reader, out T decoded)
+          where T: KrbPriv, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+            
+            DecodeApplication(reader, out decoded);
+        }
+
+        internal static void Decode<T>(AsnReader reader, Asn1Tag expectedTag, out T decoded)
+          where T: KrbPriv, new()
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            decoded = new T();
+            
+            AsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            AsnReader explicitReader;
+            
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            if (!explicitReader.TryReadInt32(out int tmpProtocolVersionNumber))
+            {
+                explicitReader.ThrowIfNotEmpty();
+            }
+            
+            decoded.ProtocolVersionNumber = tmpProtocolVersionNumber;
+
+            explicitReader.ThrowIfNotEmpty();
+
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
+
+            if (!explicitReader.TryReadInt32(out MessageType tmpMessageType))
+            {
+                explicitReader.ThrowIfNotEmpty();
+            }
+            
+            decoded.MessageType = tmpMessageType;
+
+            explicitReader.ThrowIfNotEmpty();
+
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+            KrbEncryptedData.Decode<KrbEncryptedData>(explicitReader, out KrbEncryptedData tmpEncPart);
+            decoded.EncPart = tmpEncPart;
+
+            explicitReader.ThrowIfNotEmpty();
+
+            sequenceReader.ThrowIfNotEmpty();
+        }
+    }
+}

--- a/Kerberos.NET/Entities/Krb/KrbPriv.xml
+++ b/Kerberos.NET/Entities/Krb/KrbPriv.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<asn:Sequence
+  xmlns:asn="http://schemas.dot.net/asnxml/201808/"
+  name="KrbPriv"
+  namespace="Kerberos.NET.Entities" explicitTag="21">
+  <!--
+		  KRB-PRIV        ::= [APPLICATION 21] SEQUENCE {
+			  pvno            [0] INTEGER (5),
+			  msg-type        [1] INTEGER (21),
+              // NOTE: there is no [2] tag
+			  enc-part        [3] EncryptedData // EncKrbPrivPart 
+
+          }-->
+
+  <asn:Integer name="ProtocolVersionNumber" explicitTag="0" backingType="int" />
+  <asn:Integer name="MessageType" explicitTag="1" backingType="enum" enumType="MessageType" />
+  <asn:AsnType name="EncPart" typeName="KrbEncryptedData" explicitTag="3" />
+</asn:Sequence>

--- a/Kerberos.NET/Kerberos.NET.csproj
+++ b/Kerberos.NET/Kerberos.NET.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<AsnXml Include="Entities\ChangePassword\KrbChangePasswdData.xml" />	
     <AsnXml Include="Entities\Kkdcp\KdcProxyMessage.xml" />
     <AsnXml Include="Entities\Krb\KrbETypeList.xml" />
     <AsnXml Include="Entities\Krb\KrbApReq.xml" />
@@ -34,6 +35,7 @@
     <AsnXml Include="Entities\Krb\KrbEncAsRepPart.xml" />
     <AsnXml Include="Entities\Krb\KrbEncApRepPart.xml" />
     <AsnXml Include="Entities\Krb\KrbEncKdcRepPart.xml" />
+    <AsnXml Include="Entities\Krb\KrbEncKrbPrivPart.xml" />	
     <AsnXml Include="Entities\Krb\KrbEncTgsRepPart.xml" />
     <AsnXml Include="Entities\Krb\KrbEncTicketPart.xml" />
     <AsnXml Include="Entities\Krb\KrbError.xml" />
@@ -53,6 +55,7 @@
     <AsnXml Include="Entities\Krb\KrbPaPacRequest.xml" />
     <AsnXml Include="Entities\Krb\KrbPaS4uX509User.xml" />
     <AsnXml Include="Entities\Krb\KrbPrincipalName.xml" />
+	<AsnXml Include="Entities\Krb\KrbPriv.xml" />	
     <AsnXml Include="Entities\Krb\KrbS4uUserId.xml" />
     <AsnXml Include="Entities\Krb\KrbTgsReq.xml" />
     <AsnXml Include="Entities\Krb\KrbTgsRep.xml" />

--- a/Tests/Tests.Kerberos.NET/Client/ClientTransportTests.cs
+++ b/Tests/Tests.Kerberos.NET/Client/ClientTransportTests.cs
@@ -109,7 +109,7 @@ namespace Tests.Kerberos.NET
 
             public override ClientDomainService ClientRealmService { get; } = new NoopClientRealmService();
 
-            public override Task<T> SendMessage<T>(string domain, ReadOnlyMemory<byte> req, CancellationToken cancellation = default)
+            public override Task<ReadOnlyMemory<byte>> SendMessage(string domain, ReadOnlyMemory<byte> req, CancellationToken cancellation = default)
             {
                 var cached = this.LocateKdc(domain, "_kerberos._foo");
 
@@ -136,7 +136,7 @@ namespace Tests.Kerberos.NET
                     }
                 }.EncodeApplication();
 
-                return Task.FromResult(Decode<T>(response));
+                return Task.FromResult(response);
             }
 
             private class NoopClientRealmService : ClientDomainService
@@ -146,7 +146,7 @@ namespace Tests.Kerberos.NET
                 {
                 }
 
-                protected override Task<IEnumerable<DnsRecord>> Query(string domain, string servicePrefix)
+                protected override Task<IEnumerable<DnsRecord>> Query(string domain, string servicePrefix, int defaultPort)
                 {
                     return Task.FromResult<IEnumerable<DnsRecord>>(new List<DnsRecord>
                     {

--- a/Tests/Tests.Kerberos.NET/End2End/InMemoryTransport.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/InMemoryTransport.cs
@@ -21,7 +21,7 @@ namespace Tests.Kerberos.NET
             this.Enabled = true;
         }
 
-        public override async Task<T> SendMessage<T>(
+        public override async Task<ReadOnlyMemory<byte>> SendMessage(
             string domain,
             ReadOnlyMemory<byte> req,
             CancellationToken cancellation = default
@@ -29,7 +29,7 @@ namespace Tests.Kerberos.NET
         {
             var response = await this.listener.Receive(req);
 
-            return Decode<T>(response);
+            return response;
         }
     }
 }


### PR DESCRIPTION
Example usage:
```
   var cred = new KerberosAsymmetricCredential(cert);
   var client = new KerberosClient();
   await client.ChangePassword(cred, "new password string");
```
Closes dotnet/Kerberos.NET#94

### What's the problem?

Kerberos.NET did not support RFC 3244 Kerberos Change Password Flow.

- [ ] Bugfix
- [x] New Feature

### What's the solution?

Enhance Kerberos Client to support change password flow:
1. get  TGT for kadmin/changepw using Authenticate method -> needs to support different SName
2. build appropriate request structure -> new data types needed
3. transmit to port 464 -> changes to Transport to enable this
4. parse result -> could be non-ASN.1 parseable, so catch that in KRB_ERROR.CanDecode

 - [ ] Includes unit tests
 - [x] Requires manual test

### What issue is this related to, if any?

dotnet/Kerberos.NET#94
