### PR TITLE
Support for kpasswd set password

### DIFF
--- a/Bruce/CommandLine/KerberosPasswordCommand.cs
+++ b/Bruce/CommandLine/KerberosPasswordCommand.cs
@@ -1,0 +1,151 @@
+﻿// -----------------------------------------------------------------------
+// Licensed to The .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// -----------------------------------------------------------------------
+
+using Kerberos.NET.Configuration;
+using Kerberos.NET.Credentials;
+using Kerberos.NET.Crypto;
+using Kerberos.NET.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Kerberos.NET.CommandLine
+{
+    [CommandLineCommand("kpasswd|passwd", Description = "KerberosPassword")]
+    public class KerberosPasswordCommand : BaseCommand
+    {
+        public KerberosPasswordCommand(CommandLineParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        [CommandLineParameter("config", Description = "Config")]
+        public override string ConfigurationPath { get; set; }
+
+        [CommandLineParameter("principal",
+            Required = true,
+            Description = "UserPrincipalName")]
+        public override string PrincipalName { get; set; }
+
+        [CommandLineParameter("realm", Description = "RealmName")]
+        public override string Realm { get; set; }
+
+        [CommandLineParameter("password", Description = "Password")]
+        public string Password { get; set; }
+
+        [CommandLineParameter("targname", Description = "TargName")]
+        public string TargName { get; set; }
+
+        [CommandLineParameter("targrealm", Description = "TargRealm")]
+        public string TargRealm { get; set; }
+
+        [CommandLineParameter("newpassword", Description = "NewPassword")]
+        public string NewPassword { get; set; }
+
+        [CommandLineParameter("verbose", Description = "Verbose")]
+        public override bool Verbose { get; set; }
+
+        public override async Task<bool> Execute()
+        {
+            if (await base.Execute())
+            {
+                return true;
+            }
+
+            this.WriteLine();
+
+            var client = this.CreateClient(verbose: this.Verbose);
+            var logger = this.Verbose ? this.IO.CreateVerboseLogger(labels: true) : NullLoggerFactory.Instance;
+
+            // Prompt for user password
+            string password = this.Password;
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                this.Write(SR.Resource("CommandLine_KerberosPassword_PassPrompt", this.PrincipalName));
+
+                password = this.ReadMasked();
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_CredNotFound"));
+                this.WriteLine();
+                return true;
+            }
+
+            // Provides better UX if bad password fails before prompting for new password
+            var cred = new KerberosPasswordCredential(this.PrincipalName, password, this.Realm);
+            await client.Authenticate(cred);
+
+            // Must pass targRealm with targName or it will fail on Active Directory
+            var targRealm = string.IsNullOrWhiteSpace(this.TargRealm) ? client.DefaultDomain : this.TargRealm;
+
+            // Parsing the principal provides a better prompt string
+            var targPrinc = KrbPrincipalName.FromString(this.TargName, null, targRealm);
+
+            // Prompt for new password
+            string newPassword = this.NewPassword;
+            if (string.IsNullOrWhiteSpace(newPassword))
+            {
+                this.Write(SR.Resource("CommandLine_KerberosPassword_NewPassPrompt",
+                    string.IsNullOrWhiteSpace(this.TargName) ? this.PrincipalName : targPrinc.FullyQualifiedName));
+
+                newPassword = this.ReadMasked();
+            }
+
+            if (string.IsNullOrWhiteSpace(newPassword))
+            {
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_CredNotFound"));
+                this.WriteLine();
+                return true;
+            }
+
+            // Change password or set password based on TargName parameter
+            this.WriteLine();
+            if (string.IsNullOrWhiteSpace(this.TargName))
+            {
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_Changing", this.PrincipalName));
+                await client.ChangePassword(cred, newPassword);
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_ChangeSuccess", this.PrincipalName));
+            }
+            else
+            {
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_Setting", targPrinc));
+                await client.SetPassword(cred, this.TargName, targRealm, newPassword);
+                this.WriteLine(SR.Resource("CommandLine_KerberosPassword_SetSuccess", this.TargName));
+            }
+
+            return true;
+        }
+
+        private void WriteFailure(ILoggerFactory logger, AggregateException gex)
+        {
+            if (this.Verbose)
+            {
+                this.WriteLine();
+            }
+
+            ILogger errorLog;
+
+            if (this.Verbose)
+            {
+                errorLog = logger.CreateLogger("Error");
+            }
+            else
+            {
+                errorLog = this.IO.CreateVerboseLogger().CreateLogger("Error");
+            }
+
+            foreach (var ex in gex.InnerExceptions)
+            {
+                errorLog.LogDebug(ex.Message);
+            }
+        }
+    }
+}

--- a/Bruce/Strings.Designer.cs
+++ b/Bruce/Strings.Designer.cs
@@ -1033,6 +1033,150 @@ namespace Kerberos.NET.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change password of the principal or set password of another principal..
+        /// </summary>
+        internal static string CommandLine_KerberosPassword {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password change succeeded for {0}..
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_ChangeSuccess {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_ChangeSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running kpasswd change password for {0}....
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_Changing {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_Changing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: Credential not found.
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_CredNotFound {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_CredNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New password for {0}: .
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_NewPassPrompt {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_NewPassPrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password for {0}: .
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_PassPrompt {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_PassPrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password set succeeded for {0}..
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_SetSuccess {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_SetSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running kpasswd set password for {0}....
+        /// </summary>
+        internal static string CommandLine_KerberosPassword_Setting {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPassword_Setting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provide the path to a configuration to use for initialization..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_Config {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_Config", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provide new password to set..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_NewPassword {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_NewPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Optionally provide the password to authenticate the user..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_Password {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_Password", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The principal name to use otherwise uses the current system user..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_Principal {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_Principal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provide the realm name to authenticate against..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_Realm {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_Realm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provide the principal name of user to set password of..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_TargName {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_TargName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provide the realm name of user to set password of..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_TargRealm {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_TargRealm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include detailed logging information in the kpasswd request..
+        /// </summary>
+        internal static string CommandLine_KerberosPasswordCommand_Verbose {
+            get {
+                return ResourceManager.GetString("CommandLine_KerberosPasswordCommand_Verbose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Locate and ping a KDC for the provided user to get pre-auth details..
         /// </summary>
         internal static string CommandLine_KerberosPing {

--- a/Bruce/Strings.resx
+++ b/Bruce/Strings.resx
@@ -441,6 +441,54 @@
   <data name="CommandLine_KerberosListCommand_Verbose" xml:space="preserve">
     <value>Displays all data about the cache.</value>
   </data>
+  <data name="CommandLine_KerberosPassword" xml:space="preserve">
+    <value>Change password of the principal or set password of another principal.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_Config" xml:space="preserve">
+    <value>Provide the path to a configuration to use for initialization.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_Principal" xml:space="preserve">
+    <value>The principal name to use otherwise uses the current system user.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_Realm" xml:space="preserve">
+    <value>Provide the realm name to authenticate against.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_Password" xml:space="preserve">
+    <value>Optionally provide the password to authenticate the user.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_NewPassword" xml:space="preserve">
+    <value>Provide new password to set.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_TargName" xml:space="preserve">
+    <value>Provide the principal name of user to set password of.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_TargRealm" xml:space="preserve">
+    <value>Provide the realm name of user to set password of.</value>
+  </data>
+  <data name="CommandLine_KerberosPasswordCommand_Verbose" xml:space="preserve">
+    <value>Include detailed logging information in the kpasswd request.</value>
+  </data>
+  <data name="CommandLine_KerberosPassword_PassPrompt" xml:space="preserve">
+    <value>Password for {0}: </value>
+  </data>
+  <data name="CommandLine_KerberosPassword_NewPassPrompt" xml:space="preserve">
+    <value>New password for {0}: </value>
+  </data>
+  <data name="CommandLine_KerberosPassword_CredNotFound" xml:space="preserve">
+    <value>Error: Credential not found</value>
+  </data>
+  <data name="CommandLine_KerberosPassword_Changing" xml:space="preserve">
+    <value>Running kpasswd change password for {0}...</value>
+  </data>
+  <data name="CommandLine_KerberosPassword_Setting" xml:space="preserve">
+    <value>Running kpasswd set password for {0}...</value>
+  </data>
+  <data name="CommandLine_KerberosPassword_ChangeSuccess" xml:space="preserve">
+    <value>Password change succeeded for {0}.</value>
+  </data>
+  <data name="CommandLine_KerberosPassword_SetSuccess" xml:space="preserve">
+    <value>Password set succeeded for {0}.</value>
+  </data>
   <data name="CommandLine_KerberosPing" xml:space="preserve">
     <value>Locate and ping a KDC for the provided user to get pre-auth details.</value>
   </data>


### PR DESCRIPTION
### What's the problem?

Need to use kpasswd protocol to set the password of another user.  Kerberos.NET previously only supported change password in the Client interface.

- [ ] Bugfix
- [X] New Feature

### What's the solution?

The messages were already there, because kpasswd uses the same message for both change password and set password (RFC 3244).  I just needed to add the interface to KerberosClient and pass the appropriate arguments.

 - [ ] Includes unit tests
 - [X] Requires manual test

I thought the easiest way to test this would be to just add a kpasswd command to Bruce.

![image](https://github.com/dotnet/Kerberos.NET/assets/3847897/e6fe0a64-80cc-4eb4-9b2c-a357832ab10f)


### What issue is this related to, if any?

No issue filed, but I can put one in if that would help.

One thing that I encountered was that Active Directory does not return a UTF8 string in the result string of the KRB-ERROR message.  I was hitting this because my Default Domain Policy had a Minimum Password Age of 1 day.  The error string was problematic because it was thrown as an Exception.Message and included non-printable characters.
