### PR TITLE
Handle null reference exception when TicketCacheBase.Refresh is null

### DIFF
--- a/Kerberos.NET/Cache/TicketCacheBase.cs
+++ b/Kerberos.NET/Cache/TicketCacheBase.cs
@@ -158,7 +158,7 @@ namespace Kerberos.NET
 
                 if (cacheEntry != null && !cacheEntry.IsExpired(this.Configuration.Defaults.ClockSkew))
                 {
-                    await (this.Refresh?.Invoke(cacheEntry))?.ConfigureAwait(false);
+                    await (this.Refresh?.Invoke(cacheEntry) ?? Task.CompletedTask).ConfigureAwait(false);
                 }
             }
 

--- a/Kerberos.NET/Cache/TicketCacheBase.cs
+++ b/Kerberos.NET/Cache/TicketCacheBase.cs
@@ -158,10 +158,7 @@ namespace Kerberos.NET
 
                 if (cacheEntry != null && !cacheEntry.IsExpired(this.Configuration.Defaults.ClockSkew))
                 {
-                    if (this.Refresh != null)
-                    {
-                        await this.Refresh.Invoke(cacheEntry).ConfigureAwait(false);
-                    }
+                    await (this.Refresh?.Invoke(cacheEntry))?.ConfigureAwait(false);
                 }
             }
 

--- a/Kerberos.NET/Cache/TicketCacheBase.cs
+++ b/Kerberos.NET/Cache/TicketCacheBase.cs
@@ -158,7 +158,10 @@ namespace Kerberos.NET
 
                 if (cacheEntry != null && !cacheEntry.IsExpired(this.Configuration.Defaults.ClockSkew))
                 {
-                    await (this.Refresh?.Invoke(cacheEntry)).ConfigureAwait(false);
+                    if (this.Refresh != null)
+                    {
+                        await this.Refresh.Invoke(cacheEntry).ConfigureAwait(false);
+                    }
                 }
             }
 


### PR DESCRIPTION
### What's the problem?

A `NullReferenceException` can happen when using `Krb5TicketCache`.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Evaluate whether `Refresh` is null before trying to Invoke it and `.ConfigureAwait(false)`.

 - [ ] Includes unit tests
 - [x] Requires manual test

### Background information

I inherited some code that hits a `NullReferenceException` when the cache tries to refresh. I struggled to write a test for this scenario due to the way the different objects (and default values) are instantiated, the methods being private and the nature of the background tasks involved. 

I'm still getting up to speed on everything involved, but I believe the most relevant bits I'm starting from include something like this:
```
var client = new KerberosClient(Krb5Config.Default());
client.CacheInMemory = false;
client.Cache = new Krb5TicketCache("path to cache file");
client.RenewTickets = true;
```
