### PR TITLE
Make CryptoPal implementations public

### DIFF
--- a/Kerberos.NET/Crypto/Pal/Linux/LinuxCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/Linux/LinuxCryptoPal.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -8,7 +8,7 @@ using Kerberos.NET.Crypto.Pal;
 
 namespace Kerberos.NET.Crypto
 {
-    internal class LinuxCryptoPal : CryptoPal
+    public class LinuxCryptoPal : CryptoPal
     {
         public LinuxCryptoPal()
         {

--- a/Kerberos.NET/Crypto/Pal/OSX/OSXCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/OSX/OSXCryptoPal.cs
@@ -1,11 +1,11 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
 namespace Kerberos.NET.Crypto
 {
-    internal class OSXCryptoPal : LinuxCryptoPal
+    public class OSXCryptoPal : LinuxCryptoPal
     {
         public OSXCryptoPal()
         {

--- a/Kerberos.NET/Crypto/Pal/Windows/WindowsCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/Windows/WindowsCryptoPal.cs
@@ -8,7 +8,7 @@ using Kerberos.NET.Crypto.Pal;
 
 namespace Kerberos.NET.Crypto
 {
-    internal class WindowsCryptoPal : CryptoPal
+    public class WindowsCryptoPal : CryptoPal
     {
         public WindowsCryptoPal()
         {


### PR DESCRIPTION
### What's the problem?

Cross-platform crypto cannot be extended without bringing entire crypto suite.

- [ ] Bugfix
- [X] New Feature

Fixes #379 by making the PALs public for override.