### PR TITLE
Update Nuget packages

### DIFF
--- a/Kerberos.NET/Kerberos.NET.csproj
+++ b/Kerberos.NET/Kerberos.NET.csproj
@@ -79,10 +79,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Benchmark.Kerberos.NET/Benchmark.Kerberos.NET.csproj
+++ b/Tests/Benchmark.Kerberos.NET/Benchmark.Kerberos.NET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
 
     <DebugType>pdbonly</DebugType>
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
+++ b/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
@@ -29,11 +29,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
+++ b/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
 
     <DebugType>Full</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
+++ b/Tests/Tests.Kerberos.NET/Tests.Kerberos.NET.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -21,9 +21,9 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 6.x'
+      displayName: 'Use .NET Core SDK 8.x'
       inputs:
-        version: 6.x
+        version: 8.x
         performMultiLevelLookup: true
 
     - task: DotNetCoreCLI@2

--- a/build.yaml
+++ b/build.yaml
@@ -124,9 +124,9 @@ stages:
       displayName: Download drop build artifacts
 
     - task: UseDotNet@2
-      displayName: 'Use .NET SDK 6.x'
+      displayName: 'Use .NET SDK 8.x'
       inputs:
-        version: 6.x
+        version: 8.x
 
     # Install the code signing tool
     - task: DotNetCoreCLI@2


### PR DESCRIPTION

### What's the problem?

Update System.Security.Cryptograpshy.Pkcs as it depends on System.Formats.Asn1 8.0.0 which has a vulnerability and dotnet build annoys me about it.

- [X] Maintenance
- [ ] Bugfix
- [ ] New Feature

### What's the solution?

Describe the solution here.

 - [X] Probably covered by unit tests
 - [ ] Includes unit tests
 - [ ] Requires manual test

