### PR TITLE
Just try all the keys

### DIFF
--- a/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
@@ -4,6 +4,9 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Linq;
+using System.Security;
+using System.Security.Cryptography;
 using Kerberos.NET.Entities;
 
 namespace Kerberos.NET.Crypto
@@ -65,9 +68,38 @@ namespace Kerberos.NET.Crypto
                 throw new ArgumentNullException(nameof(keytab));
             }
 
-            var key = keytab.GetKey(this.EType, this.SName);
+            var keys = keytab.GetKeys(this.EType, this.SName);
 
-            this.Decrypt(key);
+            if (!keys.Any())
+            {
+                throw new InvalidOperationException($"Could not find a key for {this.EType} and {this.SName.FullyQualifiedName}");
+            }
+
+            Exception ex = null;
+
+            foreach (var key in keys)
+            {
+                try
+                {
+                    this.Decrypt(key);
+                    return;
+                }
+                catch (CryptographicException cex)
+                {
+                    ex = cex;
+                    continue;
+                }
+                catch (SecurityException secx)
+                {
+                    ex = secx;
+                    continue;
+                }
+            }
+
+            if (ex != null)
+            {
+                throw ex;
+            }
         }
 
         public override void Decrypt(KerberosKey ticketEncryptingKey)

--- a/Kerberos.NET/Crypto/KeyTable.cs
+++ b/Kerberos.NET/Crypto/KeyTable.cs
@@ -76,16 +76,21 @@ namespace Kerberos.NET.Crypto
 
         public ICollection<KeyEntry> Entries => this.entries ??= new List<KeyEntry>();
 
-        public KerberosKey GetKey(ChecksumType type, KrbPrincipalName sname)
-        {
-            var etype = type switch
+        private static EncryptionType EncryptionTypeForChecksumType(ChecksumType type)
+            => type switch
             {
                 ChecksumType.HMAC_SHA1_96_AES128 => EncryptionType.AES128_CTS_HMAC_SHA1_96,
                 ChecksumType.HMAC_SHA1_96_AES256 => EncryptionType.AES256_CTS_HMAC_SHA1_96,
+                ChecksumType.HMAC_SHA256_128_AES128 => EncryptionType.AES128_CTS_HMAC_SHA256_128,
+                ChecksumType.HMAC_SHA384_192_AES256 => EncryptionType.AES256_CTS_HMAC_SHA384_192,
                 _ => EncryptionType.RC4_HMAC_NT,
             };
-            return this.GetKey(etype, sname);
-        }
+
+        public IEnumerable<KerberosKey> GetKeys(ChecksumType type, KrbPrincipalName sname)
+           => this.GetKeys(EncryptionTypeForChecksumType(type), sname);
+
+        public KerberosKey GetKey(ChecksumType type, KrbPrincipalName sname)
+            => this.GetKey(EncryptionTypeForChecksumType(type), sname);
 
         public IEnumerable<KerberosKey> GetKeys(EncryptionType type, KrbPrincipalName sname)
         {

--- a/Kerberos.NET/Crypto/KeyTable.cs
+++ b/Kerberos.NET/Crypto/KeyTable.cs
@@ -74,28 +74,44 @@ namespace Kerberos.NET.Crypto
 
         private ICollection<KeyEntry> entries;
 
-        public ICollection<KeyEntry> Entries => this.entries ?? (this.entries = new List<KeyEntry>());
+        public ICollection<KeyEntry> Entries => this.entries ??= new List<KeyEntry>();
 
         public KerberosKey GetKey(ChecksumType type, KrbPrincipalName sname)
         {
-            EncryptionType etype;
-
-            switch (type)
+            var etype = type switch
             {
-                case ChecksumType.HMAC_SHA1_96_AES128:
-                    etype = EncryptionType.AES128_CTS_HMAC_SHA1_96;
-                    break;
-                case ChecksumType.HMAC_SHA1_96_AES256:
-                    etype = EncryptionType.AES256_CTS_HMAC_SHA1_96;
-                    break;
+                ChecksumType.HMAC_SHA1_96_AES128 => EncryptionType.AES128_CTS_HMAC_SHA1_96,
+                ChecksumType.HMAC_SHA1_96_AES256 => EncryptionType.AES256_CTS_HMAC_SHA1_96,
+                _ => EncryptionType.RC4_HMAC_NT,
+            };
+            return this.GetKey(etype, sname);
+        }
 
-                case ChecksumType.KERB_CHECKSUM_HMAC_MD5:
-                default:
-                    etype = EncryptionType.RC4_HMAC_NT;
-                    break;
+        public IEnumerable<KerberosKey> GetKeys(EncryptionType type, KrbPrincipalName sname)
+        {
+            // try and find a matching entry
+
+            var entries = this.Entries
+                .Where(e => e.EncryptionType == type && (sname?.Matches(e.Principal) ?? true))
+                .OrderByDescending(x => x.Version);
+
+            if (!entries.Any())
+            {
+                // Fall back to first entry with matching type
+
+                entries = this.Entries
+                    .Where(e => e.EncryptionType == type)
+                    .OrderByDescending(x => x.Version);
             }
 
-            return this.GetKey(etype, sname);
+            if (!entries.Any())
+            {
+                // fall back to first entry
+
+                entries = this.Entries.OrderByDescending(x => x.Version);
+            }
+
+            return entries.Select(e => e.Key);
         }
 
         public KerberosKey GetKey(EncryptionType type, KrbPrincipalName sname)
@@ -107,22 +123,16 @@ namespace Kerberos.NET.Crypto
                 .OrderByDescending(x => x.Version)
                 .FirstOrDefault();
 
-            // Fall back to first entry with matching type (RC4_HMAC_NT)
+            // Fall back to first entry with matching type
 
-            if (entry == null)
-            {
-                entry = this.Entries
+            entry ??= this.Entries
                     .Where(e => e.EncryptionType == type)
                     .OrderByDescending(x => x.Version)
                     .FirstOrDefault();
-            }
 
             // Fall back to first entry
 
-            if (entry == null)
-            {
-                entry = this.Entries.FirstOrDefault();
-            }
+            entry ??= this.Entries.FirstOrDefault();
 
             return entry?.Key;
         }

--- a/Kerberos.NET/Entities/Pac/PacSignature.cs
+++ b/Kerberos.NET/Entities/Pac/PacSignature.cs
@@ -4,7 +4,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Ndr;
 
@@ -113,9 +116,38 @@ namespace Kerberos.NET.Entities.Pac
 
         internal void Validate(KeyTable keytab, KrbPrincipalName sname)
         {
-            var key = keytab.GetKey(this.Type, sname);
+            var keys = keytab.GetKeys(this.Type, sname);
 
-            this.Validate(key);
+            if (!keys.Any())
+            {
+                throw new InvalidOperationException($"Could not find a key for {this.Type} and {sname.FullyQualifiedName}");
+            }
+
+            Exception ex = null;
+
+            foreach (var key in keys)
+            {
+                try
+                {
+                    this.Validate(key);
+                    return;
+                }
+                catch (CryptographicException cex)
+                {
+                    ex = cex;
+                    continue;
+                }
+                catch (SecurityException secx)
+                {
+                    ex = secx;
+                    continue;
+                }
+            }
+
+            if (ex != null)
+            {
+                throw ex;
+            }
         }
 
         internal void Sign(Memory<byte> pacUnsigned, KerberosKey key)


### PR DESCRIPTION
### What's the problem?

Trying to find the right key by name is error prone and often leads to issues. It's more effective to try all keys of the given etype since it's still bound by the total length of keys in the table.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Find all keys by sname and etype and use that if it hits. Otherwise return all keys of the given etype or return all keys.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

Fixes #392 