### PR TITLE
[WIP] Flow client and target names and realms separately

### DIFF
--- a/Kerberos.NET/Configuration/Krb5RealmConfig.cs
+++ b/Kerberos.NET/Configuration/Krb5RealmConfig.cs
@@ -350,7 +350,7 @@ namespace Kerberos.NET.Configuration
         /// Compatibility shims should be enforced by the KDC.
         /// </summary>
         [EnumAsInteger]
-        [DefaultValue(KerberosCompatibilityFlags.None)]
+        [DefaultValue(KerberosCompatibilityFlags.IsolateRealmsConsistently)]
         [DisplayName("compatibility_flags")]
         public KerberosCompatibilityFlags CompatibilityFlags { get; set; }
     }

--- a/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApReq.cs
@@ -186,7 +186,7 @@ namespace Kerberos.NET.Crypto
 
             if (validation.HasFlag(ValidationActions.Realm))
             {
-                this.ValidateRealm(this.Ticket.CRealm, this.Authenticator.Realm);
+                this.ValidateRealm(this.Ticket.CRealm, this.Authenticator.CRealm);
             }
 
             var now = this.Now();

--- a/Kerberos.NET/Crypto/DecryptedKrbMessage.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbMessage.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Kerberos.NET.Entities;
+using Kerberos.NET.Server;
 using static Kerberos.NET.Entities.KerberosConstants;
 
 namespace Kerberos.NET.Crypto
@@ -19,6 +20,8 @@ namespace Kerberos.NET.Crypto
             get { return this.nowFunc ?? (this.nowFunc = () => DateTimeOffset.UtcNow); }
             set { this.nowFunc = value; }
         }
+
+        public KerberosCompatibilityFlags CompatibilityFlags { get; set; }
 
         public abstract void Validate(ValidationActions validation);
 

--- a/Kerberos.NET/Entities/Krb/KrbApReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbApReq.cs
@@ -56,7 +56,7 @@ namespace Kerberos.NET.Entities
             authenticator = new KrbAuthenticator
             {
                 CName = tgsRep.CName,
-                Realm = tgsRep.CRealm
+                CRealm = tgsRep.CRealm
             };
 
             if (rst.AuthenticatorChecksum != null)

--- a/Kerberos.NET/Entities/Krb/KrbAsRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAsRep.cs
@@ -44,6 +44,11 @@ namespace Kerberos.NET.Entities
                 rst.RealmName = realmService.Name;
             }
 
+            if (string.IsNullOrWhiteSpace(rst.ClientRealmName))
+            {
+                rst.ClientRealmName = realmService.Name;
+            }
+
             KrbPrincipalName krbtgtName = KrbPrincipalName.WellKnown.Krbtgt(rst.RealmName);
 
             if (rst.ServicePrincipal == null)

--- a/Kerberos.NET/Entities/Krb/KrbAuthenticator.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAuthenticator.cs
@@ -1,7 +1,9 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
+
+using System;
 
 namespace Kerberos.NET.Entities
 {
@@ -11,5 +13,8 @@ namespace Kerberos.NET.Entities
         {
             this.AuthenticatorVersionNumber = 5;
         }
+
+        [Obsolete("Use to property named to match the spec `CRealm`.")]
+        public string Realm { get => this.CRealm; set => this.CRealm = value; }
     }
 }

--- a/Kerberos.NET/Entities/Krb/KrbAuthenticator.generated.cs
+++ b/Kerberos.NET/Entities/Krb/KrbAuthenticator.generated.cs
@@ -33,7 +33,7 @@ namespace Kerberos.NET.Entities
     
         public int AuthenticatorVersionNumber { get; set; }
   
-        public string Realm { get; set; }
+        public string CRealm { get; set; }
   
         public KrbPrincipalName CName { get; set; }
   
@@ -63,7 +63,7 @@ namespace Kerberos.NET.Entities
             writer.WriteInteger(AuthenticatorVersionNumber);
             writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
             writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
-            writer.WriteCharacterString(UniversalTagNumber.GeneralString, Realm);
+            writer.WriteCharacterString(UniversalTagNumber.GeneralString, CRealm);
             writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
             writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
             CName?.Encode(writer);
@@ -223,7 +223,7 @@ namespace Kerberos.NET.Entities
             explicitReader.ThrowIfNotEmpty();
 
             explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
-            decoded.Realm = explicitReader.ReadCharacterString(UniversalTagNumber.GeneralString);
+            decoded.CRealm = explicitReader.ReadCharacterString(UniversalTagNumber.GeneralString);
 
             explicitReader.ThrowIfNotEmpty();
 

--- a/Kerberos.NET/Entities/Krb/KrbAuthenticator.xml
+++ b/Kerberos.NET/Entities/Krb/KrbAuthenticator.xml
@@ -18,7 +18,7 @@
           }-->
 
   <asn:Integer name="AuthenticatorVersionNumber" explicitTag="0" backingType="int" />
-  <asn:GeneralString name="Realm" explicitTag="1" />
+  <asn:GeneralString name="CRealm" explicitTag="1" />
   <asn:AsnType name="CName" typeName="KrbPrincipalName" explicitTag="2" />
   <asn:AsnType name="Checksum" typeName="KrbChecksum" explicitTag="3" optional="true" />
   <asn:Integer name="CuSec" explicitTag="4" backingType="int" />

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -66,8 +66,14 @@ namespace Kerberos.NET.Entities
 
             var rep = new T
             {
-                CName = KrbPrincipalName.FromPrincipal(request.Principal) ?? encTicketPart.CName,
-                CRealm = request.ClientRealmName ?? encTicketPart.CRealm,
+                CName = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
+                            KrbPrincipalName.FromPrincipal(request.Principal) ?? encTicketPart.CName :
+                            encTicketPart.CName,
+
+                CRealm = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
+                            request.ClientRealmName :
+                            request.RealmName,
+
                 MessageType = messageType,
                 Ticket = ticket,
                 EncPart = KrbEncryptedData.Encrypt(
@@ -110,7 +116,7 @@ namespace Kerberos.NET.Entities
             if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
             {
                 request.RealmName = request.RealmName?.ToUpperInvariant();
-                request.ClientRealmName = request.ClientRealmName?.ToUpperInvariant();
+                request.ClientRealmName = request.ClientRealmName?.ToUpperInvariant() ?? throw new InvalidOperationException("Unknown client realm name");
             }
 
             authz ??= GenerateAuthorizationData(request);
@@ -231,7 +237,12 @@ namespace Kerberos.NET.Entities
         {
             if (string.IsNullOrEmpty(request.SamAccountName))
             {
-                return KrbPrincipalName.FromPrincipal(request.Principal, realm: request.ClientRealmName);
+                return KrbPrincipalName.FromPrincipal(
+                    request.Principal,
+                    realm: request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
+                        request.ClientRealmName :
+                        request.RealmName
+                );
             }
 
             return new KrbPrincipalName

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -26,7 +26,7 @@ namespace Kerberos.NET.Entities
             ServiceTicketRequest request,
             KrbEncryptionKey sessionKey = null,
             IEnumerable<KrbAuthorizationData> authz = null
-            )
+        )
         {
             GenerateServiceTicket<KrbTgsRep>(
                 request,
@@ -46,8 +46,7 @@ namespace Kerberos.NET.Entities
             ServiceTicketRequest request,
             KrbEncryptionKey encryptionKey = null,
             IEnumerable<KrbAuthorizationData> authz = null
-            )
-            where T : KrbKdcRep, new()
+        ) where T : KrbKdcRep, new()
         {
             if (request.EncryptedPartKey == null)
             {
@@ -67,8 +66,8 @@ namespace Kerberos.NET.Entities
 
             var rep = new T
             {
-                CName = encTicketPart.CName,
-                CRealm = request.RealmName,
+                CName = KrbPrincipalName.FromPrincipal(request.Principal) ?? encTicketPart.CName,
+                CRealm = request.ClientRealmName ?? encTicketPart.CRealm,
                 MessageType = messageType,
                 Ticket = ticket,
                 EncPart = KrbEncryptedData.Encrypt(
@@ -91,8 +90,7 @@ namespace Kerberos.NET.Entities
             out KrbEncKdcRepPart encKdcRepPart,
             out KeyUsage keyUsage,
             out MessageType messageType
-        )
-            where T : KrbKdcRep, new()
+        ) where T : KrbKdcRep, new()
         {
             if (request.Principal == null)
             {
@@ -112,17 +110,12 @@ namespace Kerberos.NET.Entities
             if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
             {
                 request.RealmName = request.RealmName?.ToUpperInvariant();
+                request.ClientRealmName = request.ClientRealmName?.ToUpperInvariant();
             }
 
-            if (authz == null)
-            {
-                authz = GenerateAuthorizationData(request);
-            }
+            authz ??= GenerateAuthorizationData(request);
 
-            if (sessionKey == null)
-            {
-                sessionKey = KrbEncryptionKey.Generate(request.PreferredClientEType ?? request.ServicePrincipalKey.EncryptionType);
-            }
+            sessionKey ??= KrbEncryptionKey.Generate(request.PreferredClientEType ?? request.ServicePrincipalKey.EncryptionType);
 
             encTicketPart = CreateEncTicketPart(request, authz.ToArray(), sessionKey);
             bool appendRealm = false;
@@ -146,6 +139,7 @@ namespace Kerberos.NET.Entities
                     KeyUsage.Ticket
                 )
             };
+
             if (typeof(T) == typeof(KrbAsRep))
             {
                 encKdcRepPart = new KrbEncAsRepPart();
@@ -186,13 +180,15 @@ namespace Kerberos.NET.Entities
                     }
                 }
             };
+
             return request;
         }
 
         private static KrbEncTicketPart CreateEncTicketPart(
             ServiceTicketRequest request,
             KrbAuthorizationData[] authorizationDatas,
-            KrbEncryptionKey sessionKey)
+            KrbEncryptionKey sessionKey
+        )
         {
             var cname = CreateCNameForTicket(request);
 
@@ -205,19 +201,16 @@ namespace Kerberos.NET.Entities
 
             var addresses = request.Addresses;
 
-            if (addresses == null)
-            {
-                addresses = Array.Empty<KrbHostAddress>();
-            }
+            addresses ??= Array.Empty<KrbHostAddress>();
 
             var encTicketPart = new KrbEncTicketPart()
             {
                 CName = cname,
+                CRealm = request.ClientRealmName,
                 Key = sessionKey,
                 AuthTime = request.Now,
                 StartTime = request.StartTime,
                 EndTime = request.EndTime,
-                CRealm = request.RealmName,
                 Flags = flags,
                 AuthorizationData = authorizationDatas,
                 CAddr = addresses.ToArray(),
@@ -238,7 +231,7 @@ namespace Kerberos.NET.Entities
         {
             if (string.IsNullOrEmpty(request.SamAccountName))
             {
-                return KrbPrincipalName.FromPrincipal(request.Principal, realm: request.RealmName);
+                return KrbPrincipalName.FromPrincipal(request.Principal, realm: request.ClientRealmName);
             }
 
             return new KrbPrincipalName

--- a/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
+++ b/Kerberos.NET/Entities/Krb/KrbTgsReq.cs
@@ -207,7 +207,7 @@ namespace Kerberos.NET.Entities
             var authenticator = new KrbAuthenticator
             {
                 CName = kdcRep.CName,
-                Realm = kdcRep.CRealm,
+                CRealm = kdcRep.CRealm,
                 SequenceNumber = GetNonce(),
                 Checksum = checksum
             };

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -28,6 +28,11 @@ namespace Kerberos.NET.Entities
         public KerberosKey KdcAuthorizationKey { get; set; }
 
         /// <summary>
+        /// The realm name for which the requested identity originated
+        /// </summary>
+        public string ClientRealmName { get; set; }
+
+        /// <summary>
         /// The principal for which a service ticket is requested
         /// </summary>
         public IKerberosPrincipal Principal { get; set; }

--- a/Kerberos.NET/KerberosAuthenticator.cs
+++ b/Kerberos.NET/KerberosAuthenticator.cs
@@ -117,7 +117,7 @@ namespace Kerberos.NET
             claims.Add(new Claim(ClaimTypes.NameIdentifier, krbApReq.Ticket.CName.FullyQualifiedName, ClaimValueTypes.String, AD_AUTHORITY));
         }
 
-        private void DecodeRestrictions(
+        protected void DecodeRestrictions(
             DecryptedKrbApReq krbApReq,
             List<Claim> claims,
             List<Restriction> restrictions

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -180,7 +180,10 @@ namespace Kerberos.NET.Server
                 tgsReq.Body.SName.FullyQualifiedName,
                 tgsReq.Body.Realm);
 
-            context.ServicePrincipal = await this.RealmService.Principals.FindAsync(tgsReq.Body.SName, tgsReq.Body.Realm).ConfigureAwait(false);
+            context.ServicePrincipal = await this.RealmService.Principals.FindAsync(
+                tgsReq.Body.SName,
+                tgsReq.Body.Realm
+            ).ConfigureAwait(false);
         }
 
         public override ReadOnlyMemory<byte> ExecuteCore(PreAuthenticationContext context)
@@ -255,10 +258,9 @@ namespace Kerberos.NET.Server
             {
                 context.IncludePac = DetectPacRequirement(tgsReq);
 
-                if (context.IncludePac == null)
-                {
-                    context.IncludePac = context.Ticket?.AuthorizationData?.Any(a => a.Type == AuthorizationDataType.AdIfRelevant) ?? false;
-                }
+                context.IncludePac ??= context.Ticket?.AuthorizationData?.Any(
+                    a => a.Type == AuthorizationDataType.AdIfRelevant
+                ) ?? false;
             }
 
             var rst = new ServiceTicketRequest
@@ -269,6 +271,7 @@ namespace Kerberos.NET.Server
                 EncryptedPartEType = context.EncryptedPartEType,
                 ServicePrincipal = context.ServicePrincipal,
                 ServicePrincipalKey = serviceKey,
+                ClientRealmName = context.ClientRealm,
                 RealmName = tgsReq.Body.Realm,
                 Addresses = tgsReq.Body.Addresses,
                 RenewTill = context.Ticket.RenewTill,

--- a/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
+++ b/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
@@ -27,5 +27,11 @@ namespace Kerberos.NET.Server
         /// Do not copy the name from the TGT if the canonicalize bit is set
         /// </summary>
         DoNotCanonicalizeTgsReqFromTgt = 1 << 1,
+
+        /// <summary>
+        /// Realms are unique between the client and the target but historically they shared common
+        /// fields or properties. This separates the names into two.
+        /// </summary>
+        IsolateRealmsConsistently = 1 << 2,
     }
 }

--- a/Kerberos.NET/Server/PaDataTgsTicketHandler.cs
+++ b/Kerberos.NET/Server/PaDataTgsTicketHandler.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -94,30 +94,18 @@ namespace Kerberos.NET.Server
             // in either case we can and will validate the ticket and
             // extract the user principal from within the krbtgt ticket
 
-            var krbtgtKey = context.EvidenceTicketIdentity.RetrieveLongTermCredential();
+            var krbtgtKey = context.EvidenceTicketIdentity.RetrieveLongTermCredential()
+                ?? throw new KerberosProtocolException(KerberosErrorCode.KDC_ERR_ETYPE_NOSUPP);
 
-            if (krbtgtKey == null)
-            {
-                // since the key comes from caller-implemented code we
-                // should check to make sure they gave us a usable key
-
-                throw new KerberosProtocolException(KerberosErrorCode.KDC_ERR_ETYPE_NOSUPP);
-            }
-
-            if (context.EvidenceTicketKey == null)
-            {
-                context.EvidenceTicketKey = krbtgtKey;
-            }
+            context.EvidenceTicketKey ??= krbtgtKey;
 
             var state = context.GetState<TgsState>(PaDataType.PA_TGS_REQ);
 
-            if (state.DecryptedApReq == null)
-            {
-                state.DecryptedApReq = this.DecryptApReq(state.ApReq, context.EvidenceTicketKey);
-            }
+            state.DecryptedApReq ??= this.DecryptApReq(state.ApReq, context.EvidenceTicketKey);
 
             context.EncryptedPartKey = state.DecryptedApReq.SessionKey;
             context.Ticket = state.DecryptedApReq.Ticket;
+            context.ClientRealm = state.DecryptedApReq.Ticket.CRealm;
 
             return null;
         }

--- a/Kerberos.NET/Server/PreAuthenticationContext.cs
+++ b/Kerberos.NET/Server/PreAuthenticationContext.cs
@@ -33,6 +33,11 @@ namespace Kerberos.NET.Server
         public KerberosKey EvidenceTicketKey { get; set; }
 
         /// <summary>
+        /// The name of the realm that the client issued a TGT from.
+        /// </summary>
+        public string ClientRealm { get; set; }
+
+        /// <summary>
         /// The identity that will be the subject of the issued ticket.
         /// </summary>
         public IKerberosPrincipal Principal { get; set; }

--- a/Kerberos.NET/Server/TransitedKerberosPrincipal.cs
+++ b/Kerberos.NET/Server/TransitedKerberosPrincipal.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // Licensed to The .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
 using Kerberos.NET.Server;
@@ -16,10 +18,19 @@ namespace Kerberos.NET
     public class TransitedKerberosPrincipal : IKerberosPrincipal
     {
         private readonly DecryptedKrbApReq clientTicket;
+        private readonly PrivilegedAttributeCertificate pac;
 
         public TransitedKerberosPrincipal(DecryptedKrbApReq clientTicket)
         {
             this.clientTicket = clientTicket;
+            this.pac = DecodePac(clientTicket);
+        }
+
+        private static PrivilegedAttributeCertificate DecodePac(DecryptedKrbApReq req)
+        {
+            var authEx = new KerberosAuthenticatorEx();
+
+            return authEx.ParsePac(req);
         }
 
         public string PrincipalName => this.clientTicket.Ticket.CName.FullyQualifiedName;
@@ -32,7 +43,7 @@ namespace Kerberos.NET
 
         public DateTimeOffset? Expires => null;
 
-        public PrivilegedAttributeCertificate GeneratePac() => null;
+        public PrivilegedAttributeCertificate GeneratePac() => this.pac;
 
         public KerberosKey RetrieveLongTermCredential()
         {
@@ -47,6 +58,36 @@ namespace Kerberos.NET
         public void Validate(X509Certificate2Collection certificates)
         {
             throw new NotSupportedException();
+        }
+
+        private class KerberosAuthenticatorEx : KerberosAuthenticator
+        {
+            public KerberosAuthenticatorEx() : base(new ValidatorEx())
+            {
+            }
+
+            public PrivilegedAttributeCertificate ParsePac(DecryptedKrbApReq req)
+            {
+                var claims = new List<Claim>();
+                var restrictions = new List<Restriction>();
+
+                DecodeRestrictions(req, claims, restrictions);
+
+                return restrictions.OfType<PrivilegedAttributeCertificate>().FirstOrDefault();
+            }
+
+            private class ValidatorEx : IKerberosValidator
+            {
+                public ValidationActions ValidateAfterDecrypt
+                {
+                    get => ValidationActions.None;
+                    set => throw new NotImplementedException();
+                }
+
+                public Task<DecryptedKrbApReq> Validate(byte[] requestBytes) => throw new NotImplementedException();
+                public Task<DecryptedKrbApReq> Validate(ReadOnlyMemory<byte> requestBytes) => throw new NotImplementedException();
+                public void Validate(PrivilegedAttributeCertificate pac, KrbPrincipalName sname) => throw new NotImplementedException();
+            }
         }
     }
 }

--- a/Tests/Tests.Kerberos.NET/End2End/DomainReferralTests.cs
+++ b/Tests/Tests.Kerberos.NET/End2End/DomainReferralTests.cs
@@ -19,6 +19,10 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public async Task DomainRefersToOther()
         {
+            // user@corp -> CORP
+            // user@CORP -> CORP@OTHERREALM
+            // user@CORP[@OTHERREALM] -> fake/app@OTHERREALM
+
             var port = NextPort();
 
             using (var listener = StartListener(port))
@@ -29,7 +33,7 @@ namespace Tests.Kerberos.NET
                     FakeAdminAtCorpPassword,
                     $"127.0.0.1:{port}",
                     spn: FakeAppServiceInOtherRealm,
-                    includePac: false
+                    includePac: true
                 );
             }
         }

--- a/Tests/Tests.Kerberos.NET/FakeRealmService.cs
+++ b/Tests/Tests.Kerberos.NET/FakeRealmService.cs
@@ -13,7 +13,7 @@ namespace Tests.Kerberos.NET
     {
         private readonly KerberosCompatibilityFlags compatibilityFlags;
 
-        public FakeRealmService(string realm, Krb5Config config = null, KerberosCompatibilityFlags compatibilityFlags = KerberosCompatibilityFlags.None)
+        public FakeRealmService(string realm, Krb5Config config = null, KerberosCompatibilityFlags compatibilityFlags = KerberosCompatibilityFlags.IsolateRealmsConsistently)
         {
             this.Name = realm;
             this.Configuration = config ?? Krb5Config.Kdc();

--- a/Tests/Tests.Kerberos.NET/KrbApReq/AuthenticatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/AuthenticatorTests.cs
@@ -145,7 +145,7 @@ namespace Tests.Kerberos.NET
                 CName = KrbPrincipalName.FromString("blah@blah.com"),
                 CTime = DateTimeOffset.UtcNow,
                 CuSec = 1234,
-                Realm = "blah.com",
+                CRealm = "blah.com",
                 SequenceNumber = 123456,
                 Subkey = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96)
             };
@@ -280,6 +280,7 @@ namespace Tests.Kerberos.NET
                 ServicePrincipalKey = key,
                 IncludePac = false,
                 RealmName = "test.com",
+                ClientRealmName = "test.com",
                 Now = now,
                 StartTime = notBefore,
                 EndTime = notAfter,

--- a/Tests/Tests.Kerberos.NET/KrbApReq/KrbCredCarrierTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/KrbCredCarrierTests.cs
@@ -37,6 +37,7 @@ namespace Tests.Kerberos.NET
                 ServicePrincipalKey = key,
                 IncludePac = false,
                 RealmName = "test.com",
+                ClientRealmName = "test.com",
                 Now = DateTimeOffset.UtcNow,
                 StartTime = DateTimeOffset.UtcNow,
                 EndTime = DateTimeOffset.UtcNow.AddHours(5),

--- a/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
@@ -268,6 +268,7 @@ namespace Tests.Kerberos.NET
                 ServicePrincipalKey = key,
                 IncludePac = false,
                 RealmName = "test.com",
+                ClientRealmName = "test.com",
                 Now = now,
                 StartTime = notBefore,
                 EndTime = notAfter,

--- a/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
@@ -78,7 +78,8 @@ namespace Tests.Kerberos.NET
                 ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
                 ServicePrincipalKey = key,
                 Principal = new FakeKerberosPrincipal("blah@blah2.com"),
-                RealmName = "blah.com"
+                RealmName = "blah.com",
+                ClientRealmName = "test.com",
             });
 
             Assert.IsNotNull(ticket);
@@ -100,6 +101,7 @@ namespace Tests.Kerberos.NET
                 ServicePrincipalKey = key,
                 Principal = new FakeKerberosPrincipal("blah@blah2.com"),
                 RealmName = realm,
+                ClientRealmName = realm,
                 Compatibility = compatibilityFlags,
             });
 

--- a/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
@@ -130,7 +130,11 @@ namespace Tests.Kerberos.NET
         [DataRow(Realm, KerberosCompatibilityFlags.NormalizeRealmsUppercase, UpperCaseRealm)]
         [DataRow(UpperCaseRealm, KerberosCompatibilityFlags.None, UpperCaseRealm)]
         [DataRow(UpperCaseRealm, KerberosCompatibilityFlags.NormalizeRealmsUppercase, UpperCaseRealm)]
-        public void GeneratedTgtMatchesWithOnPremisesSamAccountName(string realm, KerberosCompatibilityFlags compatibilityFlags, string expectedRealm)
+        public void GeneratedTgtMatchesWithOnPremisesSamAccountName(
+            string realm,
+            KerberosCompatibilityFlags compatibilityFlags,
+            string expectedRealm
+        )
         {
             var realmService = new FakeRealmService(realm, compatibilityFlags: compatibilityFlags);
             var principal = realmService.Principals.Find(KrbPrincipalName.FromString(UserUpn));
@@ -155,7 +159,12 @@ namespace Tests.Kerberos.NET
             AssertIsExpectedKrbtgtWithOnPremisesSamAccountName(principalKey, rst.ServicePrincipalKey, encoded.ToArray(), expectedRealm);
         }
 
-        private static void AssertIsExpectedKrbtgtWithOnPremisesSamAccountName(KerberosKey clientKey, KerberosKey tgtKey, byte[] message, string expectedRealm)
+        private static void AssertIsExpectedKrbtgtWithOnPremisesSamAccountName(
+            KerberosKey clientKey,
+            KerberosKey tgtKey,
+            byte[] message,
+            string expectedRealm
+        )
         {
             var asRep = new KrbAsRep().DecodeAsApplication(message);
 

--- a/Tests/Tests.Kerberos.NET/Win32/LsaInteropTests.cs
+++ b/Tests/Tests.Kerberos.NET/Win32/LsaInteropTests.cs
@@ -31,6 +31,7 @@ namespace Tests.Kerberos.NET
                 ServicePrincipalKey = Key,
                 IncludePac = false,
                 RealmName = "test.com",
+                ClientRealmName = "test.com",
                 Now = DateTimeOffset.UtcNow,
                 StartTime = DateTimeOffset.UtcNow,
                 EndTime = DateTimeOffset.UtcNow.AddHours(5),


### PR DESCRIPTION
The CName and CRealm values are special values that are used to distinguish what was requested by the client and not what the target realm expects the user to be. This leads to weird problems because the SPEC says these need to remain the same and that conflicts with other implementations like MIT.

### What's the problem?

Fixes #396 

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Track the names independently from the target.

 - [X] Includes unit tests
 - [ ] Requires manual test
