### PR TITLE
Additional flexibility around session keys

### DIFF
--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -15,15 +15,19 @@ namespace Kerberos.NET.Client
 
         public KrbEncryptionKey SessionKey { get; set; }
 
+        public KrbEncryptionKey ClientSubSessionKey { get; set; }
+
+        public KrbEncryptionKey ServerSubSessionKey { get; set; }
+
         public int? SequenceNumber { get; set; }
 
         public int CuSec { get; set; }
 
         public DateTimeOffset CTime { get; set; }
 
-        public KrbEncryptionKey AuthenticateServiceResponse(string asRepEncoded)
+        public KrbEncryptionKey AuthenticateServiceResponse(string apRepEncoded)
         {
-            return AuthenticateServiceResponse(Convert.FromBase64String(asRepEncoded));
+            return AuthenticateServiceResponse(Convert.FromBase64String(apRepEncoded));
         }
 
         public KrbEncryptionKey AuthenticateServiceResponse(ReadOnlyMemory<byte> apRepBytes)
@@ -37,11 +41,35 @@ namespace Kerberos.NET.Client
                 SequenceNumber = this.SequenceNumber
             };
 
-            decrypted.Decrypt(this.SessionKey.AsKey());
+            DecryptApRep(decrypted);
 
             decrypted.Validate(ValidationActions.TokenWindow);
+            ServerSubSessionKey = decrypted.Response.SubSessionKey;
 
-            return decrypted.Response.SubSessionKey ?? this.SessionKey;
+            return ServerSubSessionKey ?? this.SessionKey;
         }
+
+        private void DecryptApRep(DecryptedKrbApRep decrypted)
+        {
+            foreach(var key in new[] {
+                this.SessionKey,
+                this.ClientSubSessionKey
+            })
+            {
+                if (key == null) continue;
+                try
+                {
+                    decrypted.Decrypt(key.AsKey());
+                    return;
+                }
+                catch (Exception)
+                {
+                    // Not this key, continue to the next one
+                }
+            }
+
+            throw new InvalidOperationException("Failed to decrypt AP_REP with any of the provided keys.");
+        }
+
     }
 }

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -882,7 +882,8 @@ namespace Kerberos.NET.Client
                         rst,
                         out KrbAuthenticator authenticator
                     ),
-                    SessionKey = authenticator.Subkey ?? serviceTicketCacheEntry.SessionKey,
+                    SessionKey = serviceTicketCacheEntry.SessionKey,
+                    ClientSubSessionKey = authenticator.Subkey,
                     CTime = authenticator.CTime,
                     CuSec = authenticator.CuSec,
                     SequenceNumber = authenticator.SequenceNumber

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -61,14 +61,6 @@ namespace Kerberos.NET.Crypto
                     nameof(this.CuSec)
                 );
             }
-
-            if (this.SequenceNumber != this.Response.SequenceNumber)
-            {
-                throw new KerberosValidationException(
-                    $"SequenceNumber does not match. Sent: {this.SequenceNumber}; Received: {this.Response.SequenceNumber}",
-                    nameof(this.SequenceNumber)
-                );
-            }
         }
     }
 }


### PR DESCRIPTION
We were able to make progress with the following changes:

- Expose SessionKey, ClientSubSessionKey and ServerSubSessionKey from ApplicationSessionContext
- Try to decrypt AP_REP with SessionKey and ClientSubSessionKey
- Remove sequence number validation on decrypted AP_REP

### What's the problem?

We are unable to implement a simple WinRM (HTTP/SOAP) connection setup using GSS-API Krb5 while simulating the WinRM protocol with Kerberos authentication.  When selecting the Kerberos authentication option, PowerShell uses Kerberos directly, not SPNEGO.

The Kerberos.NET code needs to be more flexible when trying/selecting session keys to decrypt GSS-API tokens, and it also needs to relax specific requirements around sequence number validation, because handling can vary by application.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

ApplicationSessionContext needs to keep track of sub session keys as well and try multiple options before giving up, in order to accommodate applications that may misbehave relative to common expectations and specifications.

ApplicationSessionContext should not try to validate that the sequence numbers match. 

 - [ ] Includes unit tests
 - [X] Requires manual test
  
 The provided code can be used to manually test. 

### What issue is this related to, if any?

The issue is described in #398.
