### PR TITLE
Improvements for AP-REP validation

### DIFF
--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -41,11 +41,39 @@ namespace Kerberos.NET.Client
                 SequenceNumber = this.SequenceNumber
             };
 
-            decrypted.Decrypt(this.SessionKey.AsKey());
+            DecryptApRep(decrypted);
 
             decrypted.Validate(ValidationActions.TokenWindow);
 
             return decrypted.Response.SubSessionKey ?? this.SessionKey;
+        }
+
+        private void DecryptApRep(DecryptedKrbApRep decrypted)
+        {
+            foreach (var key in new[]
+            {
+                this.SessionKey,
+                this.ServiceTicketSessionKey,
+                this.ClientSubSessionKey,
+            })
+            {
+                if (key == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    decrypted.Decrypt(key.AsKey());
+                    return;
+                }
+                catch (Exception)
+                {
+                    // Not this key, continue to the next one
+                }
+            }
+
+            throw new InvalidOperationException("Failed to decrypt AP_REP with any of the provided keys.");
         }
     }
 }

--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -73,7 +73,7 @@ namespace Kerberos.NET.Client
                 }
             }
 
-            throw new InvalidOperationException("Failed to decrypt AP_REP with any of the provided keys.");
+            throw new InvalidOperationException("Failed to decrypt AP-REP with any of the provided keys.");
         }
     }
 }

--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -15,6 +15,10 @@ namespace Kerberos.NET.Client
 
         public KrbEncryptionKey SessionKey { get; set; }
 
+        public KrbEncryptionKey ServiceTicketSessionKey { get; set; }
+
+        public KrbEncryptionKey ClientSubSessionKey { get; set; }
+
         public int? SequenceNumber { get; set; }
 
         public int CuSec { get; set; }

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -883,6 +883,8 @@ namespace Kerberos.NET.Client
                         out KrbAuthenticator authenticator
                     ),
                     SessionKey = authenticator.Subkey ?? serviceTicketCacheEntry.SessionKey,
+                    ClientSubSessionKey = authenticator.Subkey,
+                    ServiceTicketSessionKey = serviceTicketCacheEntry.SessionKey,
                     CTime = authenticator.CTime,
                     CuSec = authenticator.CuSec,
                     SequenceNumber = authenticator.SequenceNumber

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -61,14 +61,6 @@ namespace Kerberos.NET.Crypto
                     nameof(this.CuSec)
                 );
             }
-
-            //if (this.SequenceNumber != this.Response.SequenceNumber)
-            //{
-            //    throw new KerberosValidationException(
-            //        $"SequenceNumber does not match. Sent: {this.SequenceNumber}; Received: {this.Response.SequenceNumber}",
-            //        nameof(this.SequenceNumber)
-            //    );
-            //}
         }
     }
 }

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -62,13 +62,13 @@ namespace Kerberos.NET.Crypto
                 );
             }
 
-            if (this.SequenceNumber != this.Response.SequenceNumber)
-            {
-                throw new KerberosValidationException(
-                    $"SequenceNumber does not match. Sent: {this.SequenceNumber}; Received: {this.Response.SequenceNumber}",
-                    nameof(this.SequenceNumber)
-                );
-            }
+            //if (this.SequenceNumber != this.Response.SequenceNumber)
+            //{
+            //    throw new KerberosValidationException(
+            //        $"SequenceNumber does not match. Sent: {this.SequenceNumber}; Received: {this.Response.SequenceNumber}",
+            //        nameof(this.SequenceNumber)
+            //    );
+            //}
         }
     }
 }

--- a/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
+++ b/Tests/Tests.Kerberos.NET/KrbApReq/ValidatorTests.cs
@@ -383,21 +383,5 @@ namespace Tests.Kerberos.NET
 
             decrypted.Validate(ValidationActions.All);
         }
-
-        [TestMethod]
-        [ExpectedException(typeof(KerberosValidationException))]
-        public void DecryptedKrbApRep_Validate_Sequence()
-        {
-            var now = DateTimeOffset.UtcNow;
-
-            var sessionKey = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96);
-
-            var decrypted = CreateResponseMessage(now, 111, 123, sessionKey.AsKey());
-
-            decrypted.CTime = now;
-            decrypted.CuSec = 111;
-
-            decrypted.Validate(ValidationActions.All);
-        }
     }
 }


### PR DESCRIPTION
### Summary of changes:

- Expose ServiceTicketSessionKey and ClientSubSessionKey in ApplicationSessionContext while preserving existing functionality
- Try to decrypt AP-REP with all keys before failing
- Remove sequence number validation on decrypted AP-REP

### What's the problem?

We are unable to implement a simple WinRM (HTTP/SOAP) connection setup using GSS-API Krb5 while simulating the WinRM protocol with Kerberos authentication. When selecting the Kerberos authentication option for `Enter-PSSession`, PowerShell uses Kerberos directly, not SPNEGO.

This change is to have Kerberos.NET make all keys available via the `ApplicationSessionContext`  to validate GSS-API tokens.  The observed behavior that we are following is that the AP-REP is validated with the service ticket session key, and then GSS Wrap/Unwrap uses the subkey returned from the server.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

ApplicationSessionContext needs to keep track of sub session keys as well and try multiple options before giving up, in order to accommodate applications that may misbehave relative to common expectations and specifications.

ApplicationSessionContext should not try to validate that the sequence numbers match.


 - [ ] Includes unit tests
 - [X] Requires manual test
 
The code in #398 can be used to manually test.

### What issue is this related to, if any?

The issue is described in #398.