### PR TITLE
Enable `bruce` tool to run with .NET SDK 5.0 and later

### DIFF
--- a/Bruce/Bruce.csproj
+++ b/Bruce/Bruce.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Kerberos.NET.CommandLine</RootNamespace>
 
+    <RollForward>Major</RollForward>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>bruce</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>


### PR DESCRIPTION
### What's the problem?

The `bruce` tool currently targets `netcoreapp3.1`:

https://github.com/dotnet/Kerberos.NET/blob/c08a20a0847ef533e8a085a9802582461f97e992/Bruce/Bruce.csproj#L5

.NET 3.1 reached end-of-life in December 2022 (https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/), which means that most people no longer have .NET SDK 3.1 installed.

Running `bruce` on a machine with recent .NET SDKs (e.g. 8, 9 or 10) available leads to an error, e.g.:

```shell
> bruce
You must install or update .NET to run this application.

App: C:\Users\nil4\.dotnet\tools\bruce.exe
Architecture: x64
Framework: 'Microsoft.WindowsDesktop.App', version '3.1.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  9.0.8 at [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  10.0.0-preview.7.25380.108 at [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

- [ ] Bugfix
- [x] New Feature

### What's the solution?

Opt-in to roll-forward policy allowing `bruce` to be used on current and future .NET SDKs.

ref. https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior
ref. https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#rollforward

The .NET team guidance is that tools should enable the `RollForward=Major` policy to run on current and future SDK versions: 

https://github.com/dotnet/sdk/issues/26824#issuecomment-1377615531

Various Microsoft-provided tools have done so in recent years, e.g.:
- `dotnet-format`  https://github.com/dotnet/format/blob/ad8125a6fc036fe1eb4e57aa604a79f2d98d5aa0/src/dotnet-format.csproj#L11 (added in https://github.com/dotnet/format/commit/7a5df81d357992e66bf88b6dd664d70569bd7f21)
- `dotnet-ef`: https://github.com/dotnet/efcore/blob/486047c7422ec04530ca66c7c55256fa89b0ffc2/src/dotnet-ef/dotnet-ef.csproj#L24 (added in https://github.com/dotnet/efcore/commit/11e7fc66f23edf3df7eb41d3b8ed311cb2dd2b60)
- `docfx`: https://github.com/dotnet/docfx/blob/dbd57048f68411fa39aeea9ccc6c00dc88ecde9f/src/docfx/docfx.csproj#L5 (added in https://github.com/dotnet/docfx/commit/c641c038a9ee20a25500c454c57339cd98ebf8cd)

With this change applied, the tool runs as expected on current .NET SDKs, and should stay runnable on any future version.

 - [ ] Includes unit tests
 - [x] Requires manual test
