### PR TITLE
Fix difference between cname/crealm in TGS-REP cleartext vs ticket enc-part

### DIFF
--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -66,14 +66,8 @@ namespace Kerberos.NET.Entities
 
             var rep = new T
             {
-                CName = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
-                            KrbPrincipalName.FromPrincipal(request.Principal) ?? encTicketPart.CName :
-                            encTicketPart.CName,
-
-                CRealm = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
-                            request.ClientRealmName :
-                            request.RealmName,
-
+                CName = encTicketPart.CName,
+                CRealm = encTicketPart.CRealm,
                 MessageType = messageType,
                 Ticket = ticket,
                 EncPart = KrbEncryptedData.Encrypt(

--- a/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
@@ -97,6 +97,33 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public void CreateServiceTicket_ReferralTgtComputerIdentity()
+        {
+            var key = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96).AsKey();
+
+            var tgsRep = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
+            {
+                EncryptedPartKey = key,
+                ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
+                ServicePrincipalKey = key,
+                Principal = new FakeKerberosPrincipal("computer$"),
+                RealmName = "blah.com",
+                ClientRealmName = "test.com",
+                Compatibility = KerberosCompatibilityFlags.IsolateRealmsConsistently,
+            });
+
+            Assert.IsNotNull(tgsRep);
+            Assert.AreEqual("blah.com", tgsRep.Ticket.Realm);
+            Assert.AreEqual("blah@blah.com/blah.com", tgsRep.Ticket.SName.FullyQualifiedName);
+            Assert.AreEqual("test.com", tgsRep.CRealm);
+            Assert.AreEqual("computer$@test.com", tgsRep.CName.FullyQualifiedName);
+
+            var ticketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(key, KeyUsage.Ticket, KrbEncTicketPart.DecodeApplication);
+            Assert.AreEqual("test.com", ticketEncPart.CRealm);
+            Assert.AreEqual("computer$@test.com", ticketEncPart.CName.FullyQualifiedName);
+        }
+
+        [TestMethod]
         // Check that no uppercasing or realm isolation happens by default.
         [DataRow(LowerCaseRealm1, LowerCaseRealm2, KerberosCompatibilityFlags.None, LowerCaseRealm1, LowerCaseRealm1)]
         [DataRow(UpperCaseRealm1, UpperCaseRealm2, KerberosCompatibilityFlags.None, UpperCaseRealm1, UpperCaseRealm1)]


### PR DESCRIPTION
### What's the problem?

The cname and crealm fields in a KDC-REP should be the same in the cleartext body as in the enc-part of the ticket. Currently, they are generated by two slightly different implementations, which can lead to mismatches.

This is a problem, because the TGS-REP's cleartext cname/crealm get placed into the AP-REQ's Authenticator structure, see [RFC 4120 § 3.2.2. Generation of a KRB_AP_REQ Message](https://datatracker.ietf.org/doc/html/rfc4120#section-3.2.2):

> the client constructs a new Authenticator from the system time and its name

And the AP then compares the cname/crealm in Authenticator to the encrypted cname/crealm in the ticket, see  [RFC 4120 § 3.2.3. Receipt of KRB_AP_REQ Message](https://datatracker.ietf.org/doc/html/rfc4120#section-3.2.3):

> The authenticator is decrypted using the session key extracted from the decrypted ticket. [...] The name and realm of the client from the ticket are compared against the same fields in the authenticator.  If they don't match, the KRB_AP_ERR_BADMATCH error is returned.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

For TGS-REP cleartext, copy cname/crealm from the ticket enc-part instead of regenerating them.

I included a unit test that triggered the bug. Before the fix, it would return `computer$` in the cleartext, and `computer$@test.com" in the ticket enc-part. Now it returns the latter in both (principals without realms were handled differently by the code doing the ticket enc-part, compared to the code doing cleartext).

 - [x] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

None.