### PR TITLE
Ensure cname precisely matches what was in request

### DIFF
--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -243,6 +243,8 @@ namespace Kerberos.NET.Entities
 #pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrEmpty(request.SamAccountName))
             {
+                // Note that the name is returned in a single part here, even if the request may have had multiple parts.
+                // This may be okay for AS-REQs with Canonicalize set, but it is not spec-compliant for other scenarios.
                 return new KrbPrincipalName
                 {
                     Type = PrincipalNameType.NT_PRINCIPAL,
@@ -256,7 +258,8 @@ namespace Kerberos.NET.Entities
             // Note: this might not be correct in all scenarios. For instance, if the client does not accept
             // name canonicalization (i.e., the Canonicalize flag is not set), then it's not spec-compliant to deviate
             // from the requested cname. Also, in TGS-REP, the cname should match what's in the TGT, and should not be
-            // derived from the found principal.
+            // derived from the found principal. It is the responsibility of the caller to decide whether the request
+            // warrants passing Principal only, or forcing a specific cname via ClientName.
             //
             // Note: historically Kerberos.NET had a bug where the service realm was used to derive cname from the principal.
             // However, it should be the client realm. This has been corrected under the IsolateRealmsConsistently flag.

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -107,19 +107,6 @@ namespace Kerberos.NET.Entities
                 throw new InvalidOperationException("A service principal key must be provided");
             }
 
-            if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently))
-            {
-                if (request.ClientName == null)
-                {
-                    throw new InvalidOperationException("Client name must be provided when IsolateRealmsConsistently is set");
-                }
-
-                if (request.ClientRealmName == null)
-                {
-                    throw new InvalidOperationException("Client realm name must be provided when IsolateRealmsConsistently is set");
-                }
-            }
-
             if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
             {
                 request.RealmName = request.RealmName?.ToUpperInvariant();
@@ -220,7 +207,7 @@ namespace Kerberos.NET.Entities
 
             var encTicketPart = new KrbEncTicketPart()
             {
-                CName = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ? request.ClientName : CreateCNameForTicket(request),
+                CName = CreateCNameForTicket(request),
                 CRealm = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ? request.ClientRealmName : request.RealmName,
                 Key = sessionKey,
                 AuthTime = request.Now,
@@ -244,21 +231,41 @@ namespace Kerberos.NET.Entities
 
         private static KrbPrincipalName CreateCNameForTicket(ServiceTicketRequest request)
         {
-            if (string.IsNullOrEmpty(request.SamAccountName))
+            // If ClientName is explicitly set, use that. This is the preferred method for the caller to indicate what
+            // cname should be used.
+            if (request.ClientName != null)
             {
-                // This is a bug, fixed under the IsolateRealmsConsistently flag.
-                // Client realm name is not necessarily the same as the (service) realm name
-                return KrbPrincipalName.FromPrincipal(
-                    request.Principal,
-                    realm: request.RealmName
-                );
+                return request.ClientName;
             }
 
-            return new KrbPrincipalName
+            // Otherwise, if SamAccountName is set, use that as the principal name.
+            // This is not the recommended method, but is supported for backwards compatibility.
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (!string.IsNullOrEmpty(request.SamAccountName))
             {
-                Type = PrincipalNameType.NT_PRINCIPAL,
-                Name = new[] { request.SamAccountName }
-            };
+                return new KrbPrincipalName
+                {
+                    Type = PrincipalNameType.NT_PRINCIPAL,
+                    Name = new[] { request.SamAccountName }
+                };
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // Lastly, if neither are set, derive from the principal.
+            //
+            // Note: this might not be correct in all scenarios. For instance, if the client does not accept
+            // name canonicalization (i.e., the Canonicalize flag is not set), then it's not spec-compliant to deviate
+            // from the requested cname. Also, in TGS-REP, the cname should match what's in the TGT, and should not be
+            // derived from the found principal.
+            //
+            // Note: historically Kerberos.NET had a bug where the service realm was used to derive cname from the principal.
+            // However, it should be the client realm. This has been corrected under the IsolateRealmsConsistently flag.
+            return KrbPrincipalName.FromPrincipal(
+                request.Principal,
+                realm: request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
+                    request.ClientRealmName :
+                    request.RealmName
+            );
         }
 
         private static IEnumerable<KrbAuthorizationData> GenerateAuthorizationData(ServiceTicketRequest request)

--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -107,6 +107,19 @@ namespace Kerberos.NET.Entities
                 throw new InvalidOperationException("A service principal key must be provided");
             }
 
+            if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently))
+            {
+                if (request.ClientName == null)
+                {
+                    throw new InvalidOperationException("Client name must be provided when IsolateRealmsConsistently is set");
+                }
+
+                if (request.ClientRealmName == null)
+                {
+                    throw new InvalidOperationException("Client realm name must be provided when IsolateRealmsConsistently is set");
+                }
+            }
+
             if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
             {
                 request.RealmName = request.RealmName?.ToUpperInvariant();
@@ -194,8 +207,6 @@ namespace Kerberos.NET.Entities
             KrbEncryptionKey sessionKey
         )
         {
-            var cname = CreateCNameForTicket(request);
-
             var flags = request.Flags;
 
             if (request.PreAuthenticationData?.Any(r => r.Type == PaDataType.PA_REQ_ENC_PA_REP) ?? false)
@@ -209,7 +220,7 @@ namespace Kerberos.NET.Entities
 
             var encTicketPart = new KrbEncTicketPart()
             {
-                CName = cname,
+                CName = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ? request.ClientName : CreateCNameForTicket(request),
                 CRealm = request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ? request.ClientRealmName : request.RealmName,
                 Key = sessionKey,
                 AuthTime = request.Now,
@@ -235,11 +246,11 @@ namespace Kerberos.NET.Entities
         {
             if (string.IsNullOrEmpty(request.SamAccountName))
             {
+                // This is a bug, fixed under the IsolateRealmsConsistently flag.
+                // Client realm name is not necessarily the same as the (service) realm name
                 return KrbPrincipalName.FromPrincipal(
                     request.Principal,
-                    realm: request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently) ?
-                        request.ClientRealmName :
-                        request.RealmName
+                    realm: request.RealmName
                 );
             }
 

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -28,7 +28,8 @@ namespace Kerberos.NET.Entities
         public KerberosKey KdcAuthorizationKey { get; set; }
 
         /// <summary>
-        /// The client name (cname) of the identity requesting the ticket
+        /// The client name (cname) of the identity requesting the ticket.
+        /// If this is not set, <see cref="SamAccountName"/> or <see cref="Principal"/> will be used.
         /// </summary>
         public KrbPrincipalName ClientName { get; set; }
 
@@ -115,8 +116,8 @@ namespace Kerberos.NET.Entities
 
         /// <summary>
         /// SAM account name to be used to generate TGT for Windows specific user principal.
-        /// If this parameter contains valid string (not empty), CName of encrypted part of ticket
-        /// will be created based on provided SamAccountName.
+        /// This is only used if (1) <see cref="ClientName"/> is not set, and (2) it is a valid (not empty) string.
+        /// Used to compute the cname of a KDC-REP.
         /// </summary>
         public string SamAccountName { get; set; }
 

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -28,7 +28,12 @@ namespace Kerberos.NET.Entities
         public KerberosKey KdcAuthorizationKey { get; set; }
 
         /// <summary>
-        /// The realm name for which the requested identity originated
+        /// The client name (cname) of the identity requesting the ticket
+        /// </summary>
+        public KrbPrincipalName ClientName { get; set; }
+
+        /// <summary>
+        /// The client realm (crealm) name of the identity requesting the ticket
         /// </summary>
         public string ClientRealmName { get; set; }
 
@@ -179,6 +184,21 @@ namespace Kerberos.NET.Entities
                 return false;
             }
 
+            if (other.ClientName != this.ClientName)
+            {
+                return false;
+            }
+
+            if (other.ClientRealmName != this.ClientRealmName)
+            {
+                return false;
+            }
+
+            if (other.EncryptedPartEType != this.EncryptedPartEType)
+            {
+                return false;
+            }
+
             if (other.EncryptedPartKey != this.EncryptedPartKey)
             {
                 return false;
@@ -281,6 +301,10 @@ namespace Kerberos.NET.Entities
         {
             return EntityHashCode.GetHashCode(
                 this.Addresses,
+                this.ClientName,
+                this.ClientRealmName,
+                this.Compatibility,
+                this.EncryptedPartEType,
                 this.EncryptedPartKey,
                 this.EndTime,
                 this.Flags,

--- a/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
+++ b/Kerberos.NET/Entities/Krb/ServiceTicketRequest.cs
@@ -119,6 +119,9 @@ namespace Kerberos.NET.Entities
         /// This is only used if (1) <see cref="ClientName"/> is not set, and (2) it is a valid (not empty) string.
         /// Used to compute the cname of a KDC-REP.
         /// </summary>
+        [Obsolete(
+            "Using SamAccountName may cause non spec-compliant behavior. Use ClientName instead to set the client " +
+            "principal name that should be used in Kerberos responses in a spec-compliant manner.")]
         public string SamAccountName { get; set; }
 
         /// <summary>
@@ -270,10 +273,12 @@ namespace Kerberos.NET.Entities
                 return false;
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (other.SamAccountName != this.SamAccountName)
             {
                 return false;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (other.ServicePrincipal != this.ServicePrincipal)
             {
@@ -300,6 +305,7 @@ namespace Kerberos.NET.Entities
 
         public override int GetHashCode()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             return EntityHashCode.GetHashCode(
                 this.Addresses,
                 this.ClientName,
@@ -326,6 +332,7 @@ namespace Kerberos.NET.Entities
                 this.StartTime,
                 this.Compatibility
             );
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public static bool operator ==(ServiceTicketRequest left, ServiceTicketRequest right)

--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -167,12 +167,7 @@ namespace Kerberos.NET.Server
 
             var rst = new ServiceTicketRequest
             {
-                // RFC 4120 section 3.1.5 Receipt of KRB_AS_REP Message
-                // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields
-                // in the cleartext portion of the reply match what it requested."
-                ClientName = asReq.Body.CName,
                 ClientRealmName = asReq.Body.Realm,
-
                 Principal = context.Principal,
                 EncryptedPartKey = context.EncryptedPartKey,
                 EncryptedPartEType = context.EncryptedPartEType,
@@ -199,10 +194,20 @@ namespace Kerberos.NET.Server
 
             // Canonicalize means the CName in the reply is allowed to be different from the CName in the request.
             // If this is not allowed, then we must use the CName from the request. Otherwise, we will set the CName
-            // to what we have in our realm, i.e. user@realm.
+            // to what we have in our realm, i.e. user@realm (which will be inferred from the Principal set above).
+            //
+            // RFC 4120 section 3.1.5. Receipt of KRB_AS_REP Message
+            // -----------------------------------------------------
+            // If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields in
+            // the cleartext portion of the reply match what it requested.
+            //
+            // RFC 6806 section 6. Name Canonicalization
+            // -----------------------------------------
+            // If the "canonicalize" KDC option is set, then the KDC MAY change the client and server principal names
+            // and types in the AS response and ticket returned from those in the request.
             if (!asReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
-                rst.SamAccountName = asReq.Body.CName.FullyQualifiedName;
+                rst.ClientName = asReq.Body.CName;
             }
 
             if (rst.EncryptedPartKey == null)

--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -167,6 +167,12 @@ namespace Kerberos.NET.Server
 
             var rst = new ServiceTicketRequest
             {
+                // RFC 4120 section 3.1.5 Receipt of KRB_AS_REP Message
+                // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields
+                // in the cleartext portion of the reply match what it requested."
+                ClientName = asReq.Body.CName,
+                ClientRealmName = asReq.Body.Realm,
+
                 Principal = context.Principal,
                 EncryptedPartKey = context.EncryptedPartKey,
                 EncryptedPartEType = context.EncryptedPartEType,

--- a/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcAsReqMessageHandler.cs
@@ -207,7 +207,17 @@ namespace Kerberos.NET.Server
             // and types in the AS response and ticket returned from those in the request.
             if (!asReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
-                rst.ClientName = asReq.Body.CName;
+                if (this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.EnableSpecCompliantCNameHandling))
+                {
+                    rst.ClientName = asReq.Body.CName;
+                }
+                else
+                {
+                    #pragma warning disable CS0618 // Type or member is obsolete
+                    rst.SamAccountName = asReq.Body.CName.FullyQualifiedName;
+                    #pragma warning restore CS0618 // Type or member is obsolete
+                }
+                
             }
 
             if (rst.EncryptedPartKey == null)

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -265,24 +265,7 @@ namespace Kerberos.NET.Server
 
             var rst = new ServiceTicketRequest
             {
-                // In TGS-REP, we should always reply with cname/crealm copied from the TGT, even when the Canonicalize
-                // flag is set in TGS-REQ.
-                //
-                // RFC 4120 § 3.3.3 Generation of KRB_TGS_REP Message
-                // --------------------------------------------------
-                // "By default, the address field, the client's name and realm, the list of transited realms, the time
-                // of initial authentication, the expiration time, and the authorization data of the newly-issued
-                // ticket will be copied from the TGT or renewable ticket."
-                //
-                // RFC 6806 § 6. Name Canonicalization
-                // -----------------------------------
-                // "If the "canonicalize" KDC option is set, then the KDC MAY change the client and server principal
-                // names and types in the AS response and ticket returned from those in the request. Names MUST NOT be
-                // changed in the response to a TGS request, although it is common for KDCs to maintain a set of
-                // aliases for service principals."
-                ClientName = context.Ticket.CName,
                 ClientRealmName = context.Ticket.CRealm,
-
                 KdcAuthorizationKey = context.EvidenceTicketKey,
                 Principal = context.Principal,
                 EncryptedPartKey = context.EncryptedPartKey,
@@ -307,17 +290,35 @@ namespace Kerberos.NET.Server
                 Compatibility = this.RealmService.Settings.Compatibility,
             };
 
-            // The code below introduced an annoying regression in a separate party.
-            // The compatibility flag is a workaround to make sure it can use the original behavior in cases where
-            // that's expected.
-
-            if (!this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.DoNotCanonicalizeTgsReqFromTgt) &&
+            if (this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.EnableSpecCompliantCNameHandling))
+            {
+                // In TGS-REP, we should always reply with cname/crealm copied from the TGT, even when the Canonicalize
+                // flag is set in TGS-REQ.
+                //
+                // RFC 4120 § 3.3.3 Generation of KRB_TGS_REP Message
+                // --------------------------------------------------
+                // "By default, the address field, the client's name and realm, the list of transited realms, the time
+                // of initial authentication, the expiration time, and the authorization data of the newly-issued
+                // ticket will be copied from the TGT or renewable ticket."
+                //
+                // RFC 6806 § 6. Name Canonicalization
+                // -----------------------------------
+                // "If the "canonicalize" KDC option is set, then the KDC MAY change the client and server principal
+                // names and types in the AS response and ticket returned from those in the request. Names MUST NOT be
+                // changed in the response to a TGS request, although it is common for KDCs to maintain a set of
+                // aliases for service principals."
+                rst.ClientName = context.Ticket.CName;
+            }
+            else if (!this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.DoNotCanonicalizeTgsReqFromTgt) &&
                 tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
-                rst.ClientName = null;
-#pragma warning disable CS0612 // Type or member is obsolete
+                // The code below introduced an annoying regression in a separate party.
+                // The compatibility flag is a workaround to make sure it can use the original behavior in cases where
+                // that's expected.
+
+                #pragma warning disable CS0612 // Type or member is obsolete
                 rst.SamAccountName = context.GetState<TgsState>(PaDataType.PA_TGS_REQ).DecryptedApReq.Ticket.CName.FullyQualifiedName;
-#pragma warning restore CS0612 // Type or member is obsolete
+                #pragma warning restore CS0612 // Type or member is obsolete
             }
 
             // this is set here instead of in GenerateServiceTicket because GST is used by unit tests to

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -265,10 +265,21 @@ namespace Kerberos.NET.Server
 
             var rst = new ServiceTicketRequest
             {
-                // RFC 4120, section 3.3.3 Generation of KRB_TGS_REP Message:
+                // In TGS-REP, we should always reply with cname/crealm copied from the TGT, even when the Canonicalize
+                // flag is set in TGS-REQ.
+                //
+                // RFC 4120 § 3.3.3 Generation of KRB_TGS_REP Message
+                // --------------------------------------------------
                 // "By default, the address field, the client's name and realm, the list of transited realms, the time
                 // of initial authentication, the expiration time, and the authorization data of the newly-issued
                 // ticket will be copied from the TGT or renewable ticket."
+                //
+                // RFC 6806 § 6. Name Canonicalization
+                // -----------------------------------
+                // "If the "canonicalize" KDC option is set, then the KDC MAY change the client and server principal
+                // names and types in the AS response and ticket returned from those in the request. Names MUST NOT be
+                // changed in the response to a TGS request, although it is common for KDCs to maintain a set of
+                // aliases for service principals."
                 ClientName = context.Ticket.CName,
                 ClientRealmName = context.Ticket.CRealm,
 
@@ -296,12 +307,14 @@ namespace Kerberos.NET.Server
                 Compatibility = this.RealmService.Settings.Compatibility,
             };
 
-            // this introduced an annoying regression in a separate party and this is a workaround to make sure it
-            // uses the original behavior in cases where that's expected
+            // The code below introduced an annoying regression in a separate party.
+            // The compatibility flag is a workaround to make sure it can use the original behavior in cases where
+            // that's expected.
 
             if (!this.RealmService.Settings.Compatibility.HasFlag(KerberosCompatibilityFlags.DoNotCanonicalizeTgsReqFromTgt) &&
                 tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
+                rst.ClientName = null;
                 rst.SamAccountName = context.GetState<TgsState>(PaDataType.PA_TGS_REQ).DecryptedApReq.Ticket.CName.FullyQualifiedName;
             }
 

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -265,13 +265,19 @@ namespace Kerberos.NET.Server
 
             var rst = new ServiceTicketRequest
             {
+                // RFC 4120, section 3.3.3 Generation of KRB_TGS_REP Message:
+                // "By default, the address field, the client's name and realm, the list of transited realms, the time
+                // of initial authentication, the expiration time, and the authorization data of the newly-issued
+                // ticket will be copied from the TGT or renewable ticket."
+                ClientName = context.Ticket.CName,
+                ClientRealmName = context.Ticket.CRealm,
+
                 KdcAuthorizationKey = context.EvidenceTicketKey,
                 Principal = context.Principal,
                 EncryptedPartKey = context.EncryptedPartKey,
                 EncryptedPartEType = context.EncryptedPartEType,
                 ServicePrincipal = context.ServicePrincipal,
                 ServicePrincipalKey = serviceKey,
-                ClientRealmName = context.Ticket.CRealm,
                 RealmName = tgsReq.Body.Realm,
                 Addresses = tgsReq.Body.Addresses,
                 RenewTill = context.Ticket.RenewTill,

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -271,7 +271,7 @@ namespace Kerberos.NET.Server
                 EncryptedPartEType = context.EncryptedPartEType,
                 ServicePrincipal = context.ServicePrincipal,
                 ServicePrincipalKey = serviceKey,
-                ClientRealmName = context.ClientRealm,
+                ClientRealmName = context.Ticket.CRealm,
                 RealmName = tgsReq.Body.Realm,
                 Addresses = tgsReq.Body.Addresses,
                 RenewTill = context.Ticket.RenewTill,

--- a/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
+++ b/Kerberos.NET/Server/KdcTgsReqMessageHandler.cs
@@ -315,7 +315,9 @@ namespace Kerberos.NET.Server
                 tgsReq.Body.KdcOptions.HasFlag(KdcOptions.Canonicalize))
             {
                 rst.ClientName = null;
+#pragma warning disable CS0612 // Type or member is obsolete
                 rst.SamAccountName = context.GetState<TgsState>(PaDataType.PA_TGS_REQ).DecryptedApReq.Ticket.CName.FullyQualifiedName;
+#pragma warning restore CS0612 // Type or member is obsolete
             }
 
             // this is set here instead of in GenerateServiceTicket because GST is used by unit tests to

--- a/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
+++ b/Kerberos.NET/Server/KerberosCompatibilityFlags.cs
@@ -33,5 +33,12 @@ namespace Kerberos.NET.Server
         /// fields or properties. This separates the names into two.
         /// </summary>
         IsolateRealmsConsistently = 1 << 2,
+
+        /// <summary>
+        /// CName handling was historically non-spec compliant in some cases.
+        /// This flag enables handling that more strictly adheres to the spec, for better compliance
+        /// with other implementations.
+        /// </summary>
+        EnableSpecCompliantCNameHandling = 1 << 3,
     }
 }

--- a/Kerberos.NET/Server/PaDataTgsTicketHandler.cs
+++ b/Kerberos.NET/Server/PaDataTgsTicketHandler.cs
@@ -105,7 +105,6 @@ namespace Kerberos.NET.Server
 
             context.EncryptedPartKey = state.DecryptedApReq.SessionKey;
             context.Ticket = state.DecryptedApReq.Ticket;
-            context.ClientRealm = state.DecryptedApReq.Ticket.CRealm;
 
             return null;
         }

--- a/Kerberos.NET/Server/PreAuthenticationContext.cs
+++ b/Kerberos.NET/Server/PreAuthenticationContext.cs
@@ -33,11 +33,6 @@ namespace Kerberos.NET.Server
         public KerberosKey EvidenceTicketKey { get; set; }
 
         /// <summary>
-        /// The name of the realm that the client issued a TGT from.
-        /// </summary>
-        public string ClientRealm { get; set; }
-
-        /// <summary>
         /// The identity that will be the subject of the issued ticket.
         /// </summary>
         public IKerberosPrincipal Principal { get; set; }

--- a/Tests/Tests.Kerberos.NET/Client/HttpKerberosTransportTests.cs
+++ b/Tests/Tests.Kerberos.NET/Client/HttpKerberosTransportTests.cs
@@ -92,6 +92,8 @@ namespace Tests.Kerberos.NET
 
                 var rst = new ServiceTicketRequest
                 {
+                    ClientName = KrbPrincipalName.FromPrincipal(principal),
+                    ClientRealmName = Realm,
                     Principal = principal,
                     EncryptedPartKey = principalKey,
                     ServicePrincipalKey = new KerberosKey(key: TgtKey, etype: EncryptionType.AES256_CTS_HMAC_SHA1_96)

--- a/Tests/Tests.Kerberos.NET/FakeRealmService.cs
+++ b/Tests/Tests.Kerberos.NET/FakeRealmService.cs
@@ -13,7 +13,7 @@ namespace Tests.Kerberos.NET
     {
         private readonly KerberosCompatibilityFlags compatibilityFlags;
 
-        public FakeRealmService(string realm, Krb5Config config = null, KerberosCompatibilityFlags compatibilityFlags = KerberosCompatibilityFlags.IsolateRealmsConsistently)
+        public FakeRealmService(string realm, Krb5Config config = null, KerberosCompatibilityFlags compatibilityFlags = KerberosCompatibilityFlags.IsolateRealmsConsistently | KerberosCompatibilityFlags.EnableSpecCompliantCNameHandling)
         {
             this.Name = realm;
             this.Configuration = config ?? Krb5Config.Kdc();

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -26,11 +26,33 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void KdcAsReqHandler_Sync()
         {
-            KrbAsRep asRep = RequestTgt(out _);
+            KrbAsRep asRep = RequestTgt(out _, out KrbAsReq asReq);
 
             Assert.IsNotNull(asRep);
+
+            // RFC 4120 Section 3.1.5 Receipt of KRB_AS_REP Message
+            // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields in
+            // the cleartext portion of the reply match what it requested."
+            Assert.AreEqual(Realm, asReq.Body.Realm);
             Assert.AreEqual(Realm, asRep.CRealm);
+
+            Assert.AreEqual(Upn, asReq.Body.CName.FullyQualifiedName);
             Assert.AreEqual(Upn, asRep.CName.FullyQualifiedName);
+
+            // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
+            var realmService = new FakeRealmService(Realm);
+            var tgtPrincipalName = KrbPrincipalName.WellKnown.Krbtgt(Realm);
+            var tgtEncPartKey = realmService.Principals.Find(tgtPrincipalName).RetrieveLongTermCredential();
+
+            var ticketEncPart = asRep.Ticket.EncryptedPart.Decrypt(
+                tgtEncPartKey,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(ticketEncPart);
+            Assert.AreEqual(Realm, ticketEncPart.CRealm);
+            Assert.AreEqual(Upn, ticketEncPart.CName.FullyQualifiedName);
         }
 
         [TestMethod]
@@ -40,11 +62,13 @@ namespace Tests.Kerberos.NET
 
             Assert.IsNotNull(asRep);
 
+            var spn = "host/foo." + Realm;
+
             var tgsReq = KrbTgsReq.CreateTgsReq(
                 new RequestServiceTicket
                 {
                     Realm = Realm,
-                    ServicePrincipalName = "host/foo." + Realm
+                    ServicePrincipalName = spn
                 },
                 tgtKey,
                 asRep,
@@ -71,9 +95,31 @@ namespace Tests.Kerberos.NET
             );
 
             Assert.IsNotNull(encKdcRepPart);
+
+            Assert.AreEqual(Realm, tgsRep.CRealm);
+            Assert.AreEqual(Upn, tgsRep.CName.FullyQualifiedName);
+
+            // Clients can't decrypt service tickets usually, but for the sake of testing let's check what's inside
+            var realmService = new FakeRealmService(Realm);
+            var ticketEncPart = realmService.Principals.Find(KrbPrincipalName.FromString(spn)).RetrieveLongTermCredential();
+
+            var serviceTicketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(
+                ticketEncPart,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(serviceTicketEncPart);
+            Assert.AreEqual(Realm, serviceTicketEncPart.CRealm);
+            Assert.AreEqual(Upn, serviceTicketEncPart.CName.FullyQualifiedName);
         }
 
-        private static KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey)
+        private KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey)
+        {
+            return RequestTgt(out sessionKey, out _);
+        }
+
+        private KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey, out KrbAsReq asReq)
         {
             var cred = new KerberosPasswordCredential(Upn, "P@ssw0rd!")
             {
@@ -89,7 +135,7 @@ namespace Tests.Kerberos.NET
                 Configuration = Krb5Config.Default()
             };
 
-            var asReq = KrbAsReq.CreateAsReq(
+            asReq = KrbAsReq.CreateAsReq(
                 cred,
                 AuthenticationOptions.AllAuthentication
             );

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -67,32 +67,17 @@ namespace Tests.Kerberos.NET
 
             var tgsRep = KrbTgsRep.DecodeApplication(results);
 
-            Assert.IsNotNull(tgsRep);
-
-            var encKdcRepPart = tgsRep.EncPart.Decrypt(
-                sessionKey.AsKey(),
-                KeyUsage.EncTgsRepPartSubSessionKey,
-                d => KrbEncTgsRepPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(encKdcRepPart);
-
-            Assert.AreEqual(Realm, tgsRep.CRealm);
-            Assert.AreEqual(Upn, tgsRep.CName.FullyQualifiedName);
-
-            // Clients can't decrypt service tickets usually, but for the sake of testing let's check what's inside
             var realmService = new FakeRealmService(Realm);
-            var ticketEncPart = realmService.Principals.Find(KrbPrincipalName.FromString(spn)).RetrieveLongTermCredential();
+            var ticketKey = realmService.Principals.Find(KrbPrincipalName.FromString(spn)).RetrieveLongTermCredential();
 
-            var serviceTicketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(
-                ticketEncPart,
-                KeyUsage.Ticket,
-                d => KrbEncTicketPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(serviceTicketEncPart);
-            Assert.AreEqual(Realm, serviceTicketEncPart.CRealm);
-            Assert.AreEqual(Upn, serviceTicketEncPart.CName.FullyQualifiedName);
+            ValidateTgsRep(
+                tgsRep,
+                subSessionKey: sessionKey.AsKey(),
+                ticketKey: ticketKey,
+                expectedCName: Upn,
+                expectedCRealm: Realm,
+                expectedSName: spn,
+                expectedSRealm: Realm);
         }
 
         [TestMethod]
@@ -135,33 +120,18 @@ namespace Tests.Kerberos.NET
 
             var tgsRep = KrbTgsRep.DecodeApplication(results);
 
-            Assert.IsNotNull(tgsRep);
-
-            var encKdcRepPart = tgsRep.EncPart.Decrypt(
-                subSessionKey.AsKey(),
-                KeyUsage.EncTgsRepPartSubSessionKey,
-                d => KrbEncTgsRepPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(encKdcRepPart);
-
-            Assert.AreEqual(sourceRealm, tgsRep.CRealm);
-            Assert.AreEqual(Upn2WithoutRealm, tgsRep.CName.FullyQualifiedName);
-
-            // Clients can't decrypt service tickets usually, but for the sake of testing let's check what's inside
             var destRealmService = new FakeRealmService(destRealm);
             var servicePrincipal = destRealmService.Principals.Find(KrbPrincipalName.FromString(spn), destRealm);
-            var servicePrincipalKey = servicePrincipal.RetrieveLongTermCredential();
+            var ticketKey = servicePrincipal.RetrieveLongTermCredential();
 
-            var ticketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(
-                servicePrincipalKey,
-                KeyUsage.Ticket,
-                d => KrbEncTicketPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(ticketEncPart);
-            Assert.AreEqual(sourceRealm, ticketEncPart.CRealm);
-            Assert.AreEqual(Upn2WithoutRealm, ticketEncPart.CName.FullyQualifiedName);
+            ValidateTgsRep(
+                tgsRep,
+                subSessionKey: subSessionKey.AsKey(),
+                ticketKey: ticketKey,
+                expectedCName: Upn2WithoutRealm,
+                expectedCRealm: sourceRealm,
+                expectedSName: spn,
+                expectedSRealm: destRealm);
         }
 
         private void ValidateAsRep(KrbAsRep asRep, string expectedCName, string expectedCRealm, string expectedSRealm, KrbAsReq asReq = null)
@@ -193,6 +163,36 @@ namespace Tests.Kerberos.NET
 
             var ticketEncPart = asRep.Ticket.EncryptedPart.Decrypt(
                 tgtEncPartKey,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(ticketEncPart);
+            Assert.AreEqual(expectedCRealm, ticketEncPart.CRealm);
+            Assert.AreEqual(expectedCName, ticketEncPart.CName.FullyQualifiedName);
+        }
+
+        private void ValidateTgsRep(KrbTgsRep tgsRep, KerberosKey subSessionKey, KerberosKey ticketKey, string expectedCName, string expectedCRealm, string expectedSName, string expectedSRealm)
+        {
+            Assert.IsNotNull(tgsRep);
+
+            var encKdcRepPart = tgsRep.EncPart.Decrypt(
+                subSessionKey,
+                KeyUsage.EncTgsRepPartSubSessionKey,
+                d => KrbEncTgsRepPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(encKdcRepPart);
+            Assert.AreEqual(expectedCRealm, tgsRep.CRealm);
+            Assert.AreEqual(expectedCName, tgsRep.CName.FullyQualifiedName);
+
+            Assert.IsNotNull(tgsRep.Ticket);
+            Assert.AreEqual(expectedSRealm, tgsRep.Ticket.Realm);
+            Assert.AreEqual(expectedSName, tgsRep.Ticket.SName.FullyQualifiedName);
+
+            // Clients can't decrypt service tickets usually, but for the sake of testing let's check what's inside
+            var ticketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(
+                ticketKey,
                 KeyUsage.Ticket,
                 d => KrbEncTicketPart.DecodeApplication(d)
             );

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -33,16 +33,22 @@ namespace Tests.Kerberos.NET
         {
             KrbAsRep asRep = RequestTgt(cname: Upn, crealm: Realm, srealm: Realm, out _, out KrbAsReq asReq);
 
+            Assert.IsNotNull(asReq);
             Assert.IsNotNull(asRep);
 
             // RFC 4120 Section 3.1.5 Receipt of KRB_AS_REP Message
             // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields in
             // the cleartext portion of the reply match what it requested."
+            Assert.AreEqual(MessageType.KRB_AS_REP, asRep.MessageType);
             Assert.AreEqual(Realm, asReq.Body.Realm);
             Assert.AreEqual(Realm, asRep.CRealm);
 
             Assert.AreEqual(Upn, asReq.Body.CName.FullyQualifiedName);
             Assert.AreEqual(Upn, asRep.CName.FullyQualifiedName);
+
+            // Check that correct TGT was generated
+            Assert.AreEqual(Realm, asRep.Ticket.Realm);
+            Assert.AreEqual($"krbtgt/{Realm}", asRep.Ticket.SName.FullyQualifiedName);
 
             // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
             var realmService = new FakeRealmService(Realm);

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void KdcAsReqHandler_Sync()
         {
-            KrbAsRep asRep = RequestTgt(out _, out KrbAsReq asReq);
+            KrbAsRep asRep = RequestTgt(cname: Upn, crealm: Realm, srealm: Realm, out _, out KrbAsReq asReq);
 
             Assert.IsNotNull(asRep);
 
@@ -63,7 +63,7 @@ namespace Tests.Kerberos.NET
         [TestMethod]
         public void KdcTgsReqHandler_Sync()
         {
-            KrbAsRep asRep = RequestTgt(out KrbEncryptionKey tgtKey);
+            KrbAsRep asRep = RequestTgt(cname: Upn, crealm: Realm, srealm: Realm, out KrbEncryptionKey tgtKey);
 
             Assert.IsNotNull(asRep);
 
@@ -291,14 +291,14 @@ namespace Tests.Kerberos.NET
             return asRep;
         }
 
-        private KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey)
+        private KrbAsRep RequestTgt(string cname, string crealm, string srealm, out KrbEncryptionKey sessionKey)
         {
-            return RequestTgt(out sessionKey, out _);
+            return RequestTgt(cname, crealm, srealm, out sessionKey, out _);
         }
 
-        private KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey, out KrbAsReq asReq)
+        private KrbAsRep RequestTgt(string cname, string crealm, string srealm, out KrbEncryptionKey sessionKey, out KrbAsReq asReq)
         {
-            var cred = new KerberosPasswordCredential(Upn, "P@ssw0rd!")
+            var cred = new KerberosPasswordCredential(cname, "P@ssw0rd!", crealm)
             {
                 // cheating by skipping the initial leg of requesting PA-type
 
@@ -319,7 +319,7 @@ namespace Tests.Kerberos.NET
 
             var handler = new KdcAsReqMessageHandler(asReq.EncodeApplication(), new KdcServerOptions
             {
-                DefaultRealm = Realm,
+                DefaultRealm = srealm,
                 IsDebug = true,
                 RealmLocator = realm => new FakeRealmService(realm)
             });

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -33,37 +33,7 @@ namespace Tests.Kerberos.NET
         {
             KrbAsRep asRep = RequestTgt(cname: Upn, crealm: Realm, srealm: Realm, out _, out KrbAsReq asReq);
 
-            Assert.IsNotNull(asReq);
-            Assert.IsNotNull(asRep);
-
-            // RFC 4120 Section 3.1.5 Receipt of KRB_AS_REP Message
-            // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields in
-            // the cleartext portion of the reply match what it requested."
-            Assert.AreEqual(MessageType.KRB_AS_REP, asRep.MessageType);
-            Assert.AreEqual(Realm, asReq.Body.Realm);
-            Assert.AreEqual(Realm, asRep.CRealm);
-
-            Assert.AreEqual(Upn, asReq.Body.CName.FullyQualifiedName);
-            Assert.AreEqual(Upn, asRep.CName.FullyQualifiedName);
-
-            // Check that correct TGT was generated
-            Assert.AreEqual(Realm, asRep.Ticket.Realm);
-            Assert.AreEqual($"krbtgt/{Realm}", asRep.Ticket.SName.FullyQualifiedName);
-
-            // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
-            var realmService = new FakeRealmService(Realm);
-            var tgtPrincipalName = KrbPrincipalName.WellKnown.Krbtgt(Realm);
-            var tgtEncPartKey = realmService.Principals.Find(tgtPrincipalName).RetrieveLongTermCredential();
-
-            var ticketEncPart = asRep.Ticket.EncryptedPart.Decrypt(
-                tgtEncPartKey,
-                KeyUsage.Ticket,
-                d => KrbEncTicketPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(ticketEncPart);
-            Assert.AreEqual(Realm, ticketEncPart.CRealm);
-            Assert.AreEqual(Upn, ticketEncPart.CName.FullyQualifiedName);
+            ValidateAsRep(asRep, expectedCName: Upn, expectedCRealm: Realm, expectedSRealm: Realm, asReq);
         }
 
         [TestMethod]
@@ -138,21 +108,7 @@ namespace Tests.Kerberos.NET
 
             KrbAsRep asRep = CreateReferralTgt(sourceRealm, destRealm, cname, out KerberosKey tgtKey, out KerberosKey asRepKey, out KrbEncryptionKey sessionKey);
 
-            // Check the TGT we just generated
-            Assert.IsNotNull(asRep);
-            Assert.AreEqual(sourceRealm, asRep.CRealm);
-            Assert.AreEqual(Upn2WithoutRealm, asRep.CName.FullyQualifiedName);
-
-            // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
-            var tgtEncPart = asRep.Ticket.EncryptedPart.Decrypt(
-                tgtKey,
-                KeyUsage.Ticket,
-                d => KrbEncTicketPart.DecodeApplication(d)
-            );
-
-            Assert.IsNotNull(tgtEncPart);
-            Assert.AreEqual(sourceRealm, tgtEncPart.CRealm);
-            Assert.AreEqual(Upn2WithoutRealm, tgtEncPart.CName.FullyQualifiedName);
+            ValidateAsRep(asRep, expectedCName: Upn2WithoutRealm, expectedCRealm: sourceRealm, expectedSRealm: destRealm);
 
             // Send a TGS-REQ to get a service ticket in the destination realm
             var spn = "host/foo." + Realm;
@@ -206,6 +162,44 @@ namespace Tests.Kerberos.NET
             Assert.IsNotNull(ticketEncPart);
             Assert.AreEqual(sourceRealm, ticketEncPart.CRealm);
             Assert.AreEqual(Upn2WithoutRealm, ticketEncPart.CName.FullyQualifiedName);
+        }
+
+        private void ValidateAsRep(KrbAsRep asRep, string expectedCName, string expectedCRealm, string expectedSRealm, KrbAsReq asReq = null)
+        {
+            Assert.IsNotNull(asRep);
+
+            // RFC 4120 Section 3.1.5 Receipt of KRB_AS_REP Message
+            // "If the reply message type is KRB_AS_REP, then the client verifies that the cname and crealm fields in
+            // the cleartext portion of the reply match what it requested."
+            Assert.AreEqual(MessageType.KRB_AS_REP, asRep.MessageType);
+            Assert.AreEqual(expectedCRealm, asRep.CRealm);
+            Assert.AreEqual(expectedCName, asRep.CName.FullyQualifiedName);
+
+            // Optionally double check that the AS-REQ also matches
+            if (asReq != null)
+            {
+                Assert.AreEqual(Realm, asReq.Body.Realm);
+                Assert.AreEqual(Upn, asReq.Body.CName.FullyQualifiedName);
+            }
+
+            // Check that correct TGT was generated
+            Assert.AreEqual(expectedSRealm, asRep.Ticket.Realm);
+            Assert.AreEqual($"krbtgt/{expectedSRealm}", asRep.Ticket.SName.FullyQualifiedName);
+
+            // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
+            var realmService = new FakeRealmService(Realm);
+            var tgtPrincipalName = KrbPrincipalName.WellKnown.Krbtgt(Realm);
+            var tgtEncPartKey = realmService.Principals.Find(tgtPrincipalName).RetrieveLongTermCredential();
+
+            var ticketEncPart = asRep.Ticket.EncryptedPart.Decrypt(
+                tgtEncPartKey,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(ticketEncPart);
+            Assert.AreEqual(expectedCRealm, ticketEncPart.CRealm);
+            Assert.AreEqual(expectedCName, ticketEncPart.CName.FullyQualifiedName);
         }
 
         private KrbAsRep CreateReferralTgt(string sourceRealm, string destRealm, KrbPrincipalName cname, out KerberosKey tgtKey, out KerberosKey asRepKey, out KrbEncryptionKey sessionKey)

--- a/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
+++ b/Tests/Tests.Kerberos.NET/Kdc/KdcHandlerTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Kerberos.NET;
@@ -22,6 +23,10 @@ namespace Tests.Kerberos.NET
     {
         private const string Realm = "CORP2.IDENTITYINTERVENTION.COM";
         private const string Upn = "fake@" + Realm;
+
+        private const string Realm2 = "TEST.COM";
+        private const string Upn2WithoutRealm = "fakeuser";
+        // private const string Upn2WithoutRealm = "fakeuser@" + Realm2;
 
         [TestMethod]
         public void KdcAsReqHandler_Sync()
@@ -112,6 +117,178 @@ namespace Tests.Kerberos.NET
             Assert.IsNotNull(serviceTicketEncPart);
             Assert.AreEqual(Realm, serviceTicketEncPart.CRealm);
             Assert.AreEqual(Upn, serviceTicketEncPart.CName.FullyQualifiedName);
+        }
+
+        [TestMethod]
+        public void KdcTgsReqHandler_Sync_ReferralTgt()
+        {
+            var sourceRealm = Realm2;
+            var destRealm = Realm;
+            var cname = new KrbPrincipalName
+            {
+                Type = PrincipalNameType.NT_PRINCIPAL,
+                Name = new[] { Upn2WithoutRealm }
+            };
+
+            KrbAsRep asRep = CreateReferralTgt(sourceRealm, destRealm, cname, out KerberosKey tgtKey, out KerberosKey asRepKey, out KrbEncryptionKey sessionKey);
+
+            // Check the TGT we just generated
+            Assert.IsNotNull(asRep);
+            Assert.AreEqual(sourceRealm, asRep.CRealm);
+            Assert.AreEqual(Upn2WithoutRealm, asRep.CName.FullyQualifiedName);
+
+            // Clients can't decrypt TGTs usually, but for the sake of testing let's check what's inside
+            var tgtEncPart = asRep.Ticket.EncryptedPart.Decrypt(
+                tgtKey,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(tgtEncPart);
+            Assert.AreEqual(sourceRealm, tgtEncPart.CRealm);
+            Assert.AreEqual(Upn2WithoutRealm, tgtEncPart.CName.FullyQualifiedName);
+
+            // Send a TGS-REQ to get a service ticket in the destination realm
+            var spn = "host/foo." + Realm;
+
+            var tgsReq = KrbTgsReq.CreateTgsReq(
+                new RequestServiceTicket
+                {
+                    Realm = Realm,
+                    ServicePrincipalName = spn
+                },
+                sessionKey,
+                asRep,
+                out KrbEncryptionKey subSessionKey
+            );
+
+            var handler = new KdcTgsReqMessageHandler(tgsReq.EncodeApplication(), new KdcServerOptions
+            {
+                DefaultRealm = destRealm,
+                IsDebug = true,
+                RealmLocator = realm => new FakeRealmService(realm)
+            });
+
+            var results = handler.Execute();
+
+            var tgsRep = KrbTgsRep.DecodeApplication(results);
+
+            Assert.IsNotNull(tgsRep);
+
+            var encKdcRepPart = tgsRep.EncPart.Decrypt(
+                subSessionKey.AsKey(),
+                KeyUsage.EncTgsRepPartSubSessionKey,
+                d => KrbEncTgsRepPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(encKdcRepPart);
+
+            Assert.AreEqual(sourceRealm, tgsRep.CRealm);
+            Assert.AreEqual(Upn2WithoutRealm, tgsRep.CName.FullyQualifiedName);
+
+            // Clients can't decrypt service tickets usually, but for the sake of testing let's check what's inside
+            var destRealmService = new FakeRealmService(destRealm);
+            var servicePrincipal = destRealmService.Principals.Find(KrbPrincipalName.FromString(spn), destRealm);
+            var servicePrincipalKey = servicePrincipal.RetrieveLongTermCredential();
+
+            var ticketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(
+                servicePrincipalKey,
+                KeyUsage.Ticket,
+                d => KrbEncTicketPart.DecodeApplication(d)
+            );
+
+            Assert.IsNotNull(ticketEncPart);
+            Assert.AreEqual(sourceRealm, ticketEncPart.CRealm);
+            Assert.AreEqual(Upn2WithoutRealm, ticketEncPart.CName.FullyQualifiedName);
+        }
+
+        private KrbAsRep CreateReferralTgt(string sourceRealm, string destRealm, KrbPrincipalName cname, out KerberosKey tgtKey, out KerberosKey asRepKey, out KrbEncryptionKey sessionKey)
+        {
+            var sourceRealmService = new FakeRealmService(sourceRealm);
+
+            var sname = KrbPrincipalName.WellKnown.Krbtgt(destRealm);
+            var servicePrincipal = sourceRealmService.Principals.Find(sname, destRealm);
+            tgtKey = servicePrincipal.RetrieveLongTermCredential();
+
+            var clientPrincipal = sourceRealmService.Principals.Find(cname, sourceRealm);
+            asRepKey = clientPrincipal.RetrieveLongTermCredential();
+
+            sessionKey = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA256_128);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            var encTicketPart = new KrbEncTicketPart()
+            {
+                CName = cname,
+                CRealm = sourceRealm,
+                Key = sessionKey,
+                AuthTime = now,
+                StartTime = now,
+                EndTime = now.AddHours(1),
+                RenewTill = now.AddDays(30),
+                Flags = TicketFlags.PreAuthenticated | TicketFlags.Initial | TicketFlags.Renewable | TicketFlags.Forwardable,
+                AuthorizationData = null,
+                CAddr = new KrbHostAddress[] { },
+                Transited = new KrbTransitedEncoding()
+            };
+
+            KrbTicket ticket = new KrbTicket()
+            {
+                Realm = destRealm,
+                SName = sname,
+                EncryptedPart = KrbEncryptedData.Encrypt(
+                    encTicketPart.EncodeApplication(),
+                    tgtKey,
+                    KeyUsage.Ticket
+                )
+            };
+
+            KrbEncAsRepPart encAsRepPart = new KrbEncAsRepPart
+            {
+                AuthTime = encTicketPart.AuthTime,
+                StartTime = encTicketPart.AuthTime,
+                EndTime = encTicketPart.EndTime,
+                RenewTill = encTicketPart.RenewTill,
+                KeyExpiration = servicePrincipal.Expires,
+                Realm = destRealm,
+                SName = sname,
+                Flags = encTicketPart.Flags,
+                CAddr = encTicketPart.CAddr,
+                Key = sessionKey,
+                Nonce = 1234567890,
+                LastReq = new[] { new KrbLastReq { Type = 0, Value = now } },
+                EncryptedPaData = new KrbMethodData
+                {
+                    MethodData = new[]
+                    {
+                        new KrbPaData
+                        {
+                            Type = PaDataType.PA_SUPPORTED_ETYPES,
+                            Value = servicePrincipal.SupportedEncryptionTypes.AsReadOnlyMemory(littleEndian: true)
+                        }
+                    }
+                }
+            };
+
+            KrbAsRep asRep = new KrbAsRep
+            {
+                CRealm = Realm2,
+                CName = new KrbPrincipalName
+                {
+                    Type = PrincipalNameType.NT_PRINCIPAL,
+                    Name = new[] { Upn2WithoutRealm }
+                },
+                MessageType = MessageType.KRB_AS_REP,
+                Ticket = ticket,
+                EncPart = KrbEncryptedData.Encrypt(
+                    encAsRepPart.EncodeApplication(),
+                    asRepKey,
+                    asRepKey.EncryptionType,
+                    KeyUsage.EncAsRepPart
+                )
+            };
+
+            return asRep;
         }
 
         private KrbAsRep RequestTgt(out KrbEncryptionKey sessionKey)

--- a/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
@@ -112,12 +112,15 @@ namespace Tests.Kerberos.NET
 
             var tgsRep = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
             {
-                EncryptedPartKey = key,
+                ClientName = KrbPrincipalName.FromString("blah@test.com"),
+                ClientRealmName = "test.com",
+                Principal = new FakeKerberosPrincipal("blah@test.com"),
+
                 ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
                 ServicePrincipalKey = key,
-                Principal = new FakeKerberosPrincipal("blah@blah2.com"),
                 RealmName = "blah.com",
-                ClientRealmName = "test.com",
+
+                EncryptedPartKey = key,
                 Compatibility = KerberosCompatibilityFlags.IsolateRealmsConsistently,
             });
 
@@ -125,11 +128,11 @@ namespace Tests.Kerberos.NET
             Assert.AreEqual("blah.com", tgsRep.Ticket.Realm);
             Assert.AreEqual("blah@blah.com/blah.com", tgsRep.Ticket.SName.FullyQualifiedName);
             Assert.AreEqual("test.com", tgsRep.CRealm);
-            Assert.AreEqual("blah@blah2.com", tgsRep.CName.FullyQualifiedName);
+            Assert.AreEqual("blah@test.com", tgsRep.CName.FullyQualifiedName);
 
             var ticketEncPart = tgsRep.Ticket.EncryptedPart.Decrypt(key, KeyUsage.Ticket, KrbEncTicketPart.DecodeApplication);
             Assert.AreEqual("test.com", ticketEncPart.CRealm);
-            Assert.AreEqual("blah@blah2.com", ticketEncPart.CName.FullyQualifiedName);
+            Assert.AreEqual("blah@test.com", ticketEncPart.CName.FullyQualifiedName);
         }
 
         [TestMethod]
@@ -184,12 +187,14 @@ namespace Tests.Kerberos.NET
 
             var tgsRep = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
             {
+                Principal = new FakeKerberosPrincipal($"blah@{crealm}"),
+                ClientName = KrbPrincipalName.FromString($"blah@{crealm}"),
+                ClientRealmName = crealm,
+
                 EncryptedPartKey = key,
                 ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
                 ServicePrincipalKey = key,
-                Principal = new FakeKerberosPrincipal("blah@blah2.com"),
                 RealmName = realm,
-                ClientRealmName = crealm,
                 Compatibility = compatibilityFlags,
             });
 

--- a/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbtgtTests.cs
@@ -141,6 +141,7 @@ namespace Tests.Kerberos.NET
 
             var principalKey = principal.RetrieveLongTermCredential();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var rst = new ServiceTicketRequest
             {
                 SamAccountName = TestSamAccountName,
@@ -149,6 +150,7 @@ namespace Tests.Kerberos.NET
                 EncryptedPartKey = principalKey,
                 ServicePrincipalKey = new KerberosKey(key: TgtKey, etype: EncryptionType.AES256_CTS_HMAC_SHA1_96)
             };
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var tgt = KrbAsRep.GenerateTgt(rst, realmService);
 


### PR DESCRIPTION
### What's the problem?

The current handling of cname is not always spec-compliant. The spec requires the Kerberos server to essentially echo back cname and crealm to the client. However, in some scenarios, Kerberos.NET responds with a slightly different cname.

This is an issue for Kerberos clients that check that the cname in the response exactly matches what was in the request (such as MIT krb5, see [code pointer](https://github.com/krb5/krb5/blob/master/src/lib/krb5/krb/gc_via_tkt.c#L268C9-L269C43)).

The current handling of cname is only subtly wrong. It works in the most common scenario (let's call this scenario 1), where:

- cname is `["username", "realm"]`
- crealm is `"realm"`

However, it does not work in this scenario (let's call this scenario 2):

- cname is `["username"]`
- crealm is `"realm"`

This latter scenario can occur in practice. For instance, see the Wireshark trace below, where a Linux client got a referral TGT from an on-prem AD DS server. The cname only has one part.

<img width="428" height="341" alt="image" src="https://github.com/user-attachments/assets/c22f1478-0314-4cce-854c-ed9a189133d7" />

Using this referral TGT gave 

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Currently Kerberos.NET uses `crealm` and `cname` from the request to `Find` an `IKerberosPrincipal`, and then re-constructs `cname` and `crealm` fields in the response from the found principal.

However, this conversion from `cname`/`crealm` to `IKerberosPrincipal` isn't injective. In both scenarios 1 and 2, we can find the same client principal from the `cname` and `crealm` fields. When we convert that principal back to `cname` and `crealm`, we don't necessarily get the same values back.

The solution is to copy cname and crealm from the request. This aligns with the spec, section [3.3.3 Generation of KRB_TGS_REP Message](https://datatracker.ietf.org/doc/html/rfc4120#section-3.3.3):

> By default, the address field, the client's name and realm, the list of transited realms, the time of initial authentication, the expiration time, and the authorization data of the newly-issued ticket will be copied from the TGT or renewable ticket.

 - [x] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

None.