### PR TITLE
Avoid exception when ClientRealmName is null and IsolateRealmsConsistently is off

### DIFF
--- a/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
+++ b/Kerberos.NET/Entities/Krb/KrbKdcRep.cs
@@ -116,7 +116,11 @@ namespace Kerberos.NET.Entities
             if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.NormalizeRealmsUppercase))
             {
                 request.RealmName = request.RealmName?.ToUpperInvariant();
-                request.ClientRealmName = request.ClientRealmName?.ToUpperInvariant() ?? throw new InvalidOperationException("Unknown client realm name");
+
+                if (request.Compatibility.HasFlag(KerberosCompatibilityFlags.IsolateRealmsConsistently))
+                {
+                    request.ClientRealmName = request.ClientRealmName?.ToUpperInvariant() ?? throw new InvalidOperationException("Unknown client realm name");
+                }
             }
 
             authz ??= GenerateAuthorizationData(request);

--- a/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
+++ b/Tests/Tests.Kerberos.NET/Messages/KrbKdcRepTests.cs
@@ -70,6 +70,42 @@ namespace Tests.Kerberos.NET
         }
 
         [TestMethod]
+        public void CreateServiceTicket_NullClientRealmName()
+        {
+            var key = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96).AsKey();
+
+            // This should not throw, as ClientRealmName is allowed to be null if CompatibilityFlags.IsolateRealmsConsistently is not set
+            var tgsRep = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
+            {
+                EncryptedPartKey = key,
+                ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
+                ServicePrincipalKey = key,
+                Principal = new FakeKerberosPrincipal("blah@blah2.com"),
+                RealmName = "blah.com",
+                ClientRealmName = null,
+                Compatibility = KerberosCompatibilityFlags.NormalizeRealmsUppercase,
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CreateServiceTicket_NullClientRealmName_IsolateRealmsConsistently()
+        {
+            var key = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96).AsKey();
+
+            var tgsRep = KrbKdcRep.GenerateServiceTicket<KrbTgsRep>(new ServiceTicketRequest
+            {
+                EncryptedPartKey = key,
+                ServicePrincipal = new FakeKerberosPrincipal("blah@blah.com"),
+                ServicePrincipalKey = key,
+                Principal = new FakeKerberosPrincipal("blah@blah2.com"),
+                RealmName = "blah.com",
+                ClientRealmName = null,
+                Compatibility = KerberosCompatibilityFlags.NormalizeRealmsUppercase | KerberosCompatibilityFlags.IsolateRealmsConsistently,
+            });
+        }
+
+        [TestMethod]
         public void CreateServiceTicket()
         {
             var key = KrbEncryptionKey.Generate(EncryptionType.AES128_CTS_HMAC_SHA1_96).AsKey();


### PR DESCRIPTION
### What's the problem?

#397 throws an exception in `GenerateServiceTicket` if `ClientRealmName` is null and if `NormalizeRealmsUppercase` is set. This broke backwards compat.

`ClientRealmName` is only used under the `IsolateRealmsConsistently`, so it should be okay to pass a null value when the flag isn't set.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Only throw an exception if `IsolateRealmsConsistently` is set.

 - [x] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

None
