### PR TITLE
Allow caller to pass client to authenticator

### DIFF
--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -260,6 +260,30 @@ namespace Kerberos.NET.Client
         }
 
         /// <summary>
+        /// Create a new Kerberos client based on the configuration of an existing client or create a new one from scratch.
+        /// </summary>
+        /// <param name="delegationClient">The client to copy from</param>
+        /// <param name="config">The config to pass in if the client is null</param>
+        /// <param name="logger">The logger to use for the new client</param>
+        /// <returns></returns>
+        internal static KerberosClient CopyOrCreate(KerberosClient delegationClient, Krb5Config config, ILoggerFactory logger)
+        {
+            if (delegationClient == null)
+            {
+                return new KerberosClient(config, logger) { CacheInMemory = true };
+            }
+
+            return new KerberosClient(
+                delegationClient.Configuration ?? config,
+                delegationClient.loggerFactory ?? logger,
+                delegationClient.Transports.ToArray()
+            )
+            {
+                CacheInMemory = true
+            };
+        }
+
+        /// <summary>
         /// Reset any connection state that may be cached from previous attempts.
         /// </summary>
         public void ResetConnections()

--- a/Kerberos.NET/KerberosAuthenticator.cs
+++ b/Kerberos.NET/KerberosAuthenticator.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Kerberos.NET.Client;
 using Kerberos.NET.Configuration;
 using Kerberos.NET.Crypto;
 using Kerberos.NET.Entities;
@@ -27,17 +28,21 @@ namespace Kerberos.NET
 
         public UserNameFormat UserNameFormat { get; set; } = UserNameFormat.UserPrincipalName;
 
-        public KerberosAuthenticator(string upn, KeyTable keytab, Krb5Config config, ILoggerFactory logger = null)
+        public KerberosAuthenticator(string upn, KeyTable keytab, KerberosClient delegationClient, ILoggerFactory logger = null)
             : this(new KerberosValidator(keytab, logger))
         {
             if (!string.IsNullOrWhiteSpace(upn))
             {
-                this.s4uProvider = new S4UProviderFactory(upn, keytab, config, logger);
+                this.s4uProvider = new S4UProviderFactory(upn, keytab, delegationClient, delegationClient?.Configuration, logger);
             }
         }
 
+        public KerberosAuthenticator(string upn, KeyTable keytab, Krb5Config config = null, ILoggerFactory logger = null)
+            : this(upn, keytab, new KerberosClient(config, logger) { CacheInMemory = true }, logger)
+        { }
+
         public KerberosAuthenticator(KeyTable keytab, ILoggerFactory logger = null)
-            : this(null, keytab, null, logger)
+            : this(null, keytab, (Krb5Config)null, logger)
         {
 
         }

--- a/Kerberos.NET/S4UProviderFactory.cs
+++ b/Kerberos.NET/S4UProviderFactory.cs
@@ -16,9 +16,9 @@ namespace Kerberos.NET
         private readonly KerberosClient client;
         private readonly KerberosCredential credential;
 
-        public S4UProviderFactory(string upn, KeyTable keytab, Krb5Config config = null, ILoggerFactory logger = null)
+        public S4UProviderFactory(string upn, KeyTable keytab, KerberosClient delegationClient, Krb5Config config = null, ILoggerFactory logger = null)
         {
-            this.client = new KerberosClient(config, logger) { CacheInMemory = true };
+            this.client = KerberosClient.CopyOrCreate(delegationClient, config, logger);
             this.credential = new KeytabCredential(upn, keytab);
         }
 


### PR DESCRIPTION
This allows the authenticator delegation to use the existing client configuration.

### What's the problem?

Delegation client doesn't allow you to specify client-specific configuration like transport.

- [X] Bugfix
- [ ] New Feature

### What's the solution?

Add support to pass in an existing client so the configuration can be copied.

 - [X] Includes unit tests
 - [ ] Requires manual test

### What issue is this related to, if any?

#410 
