### PR TITLE
Switch to overridable platform check

### DIFF
--- a/Kerberos.NET/Crypto/Pal/CryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/CryptoPal.cs
@@ -9,6 +9,11 @@ namespace Kerberos.NET.Crypto
 {
     public abstract class CryptoPal
     {
+        protected CryptoPal()
+        {
+            this.PlatformCheck();
+        }
+
         protected static bool IsWindows => OSPlatform.IsWindows;
 
         protected static bool IsLinux => OSPlatform.IsLinux;
@@ -18,13 +23,17 @@ namespace Kerberos.NET.Crypto
         public static CryptoPal Platform => lazyPlatform.Value;
 
         private static readonly Lazy<CryptoPal> lazyPlatform
-            = new Lazy<CryptoPal>(() => CreatePal());
+            = new(() => CreatePal());
 
         private static Func<CryptoPal> injectedPal;
 
         public static void RegisterPal(Func<CryptoPal> palFunc)
         {
             injectedPal = palFunc ?? throw new InvalidOperationException("Cannot register a null PAL");
+        }
+
+        protected virtual void PlatformCheck()
+        {
         }
 
         private static CryptoPal CreatePal()
@@ -40,15 +49,13 @@ namespace Kerberos.NET.Crypto
             {
                 return new WindowsCryptoPal();
             }
-
-            if (IsLinux)
-            {
-                return new LinuxCryptoPal();
-            }
-
-            if (IsOsX)
+            else if (IsOsX)
             {
                 return new OSXCryptoPal();
+            }
+            else if (IsLinux)
+            {
+                return new LinuxCryptoPal();
             }
 
             throw PlatformNotSupported();

--- a/Kerberos.NET/Crypto/Pal/Linux/LinuxCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/Linux/LinuxCryptoPal.cs
@@ -10,7 +10,7 @@ namespace Kerberos.NET.Crypto
 {
     public class LinuxCryptoPal : CryptoPal
     {
-        public LinuxCryptoPal()
+        protected override void PlatformCheck()
         {
             if (!IsLinux)
             {

--- a/Kerberos.NET/Crypto/Pal/OSX/OSXCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/OSX/OSXCryptoPal.cs
@@ -7,7 +7,7 @@ namespace Kerberos.NET.Crypto
 {
     public class OSXCryptoPal : LinuxCryptoPal
     {
-        public OSXCryptoPal()
+        protected override void PlatformCheck()
         {
             if (!IsOsX)
             {

--- a/Kerberos.NET/Crypto/Pal/Windows/WindowsCryptoPal.cs
+++ b/Kerberos.NET/Crypto/Pal/Windows/WindowsCryptoPal.cs
@@ -10,7 +10,7 @@ namespace Kerberos.NET.Crypto
 {
     public class WindowsCryptoPal : CryptoPal
     {
-        public WindowsCryptoPal()
+        protected override void PlatformCheck()
         {
             if (!IsWindows)
             {


### PR DESCRIPTION
### What's the problem?

Mac OSX uses the Linux crypto PAL but the Linux check doesn't recognize Mac as a Linux platform which causes it to throw.

- [ ] Bugfix
- [ ] New Feature

### What's the solution?

Allow Mac to override the Linux check.

 - [ ] Includes unit tests
 - [X] Requires manual test

### What issue is this related to, if any?

Fixes #413
