### PR TITLE
Changing encoding for GeneralString to UTF8

### DIFF
--- a/Kerberos.NET/Asn1/Experimental/GeneralStringEncoding.cs
+++ b/Kerberos.NET/Asn1/Experimental/GeneralStringEncoding.cs
@@ -3,9 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
+using System.Text;
+
 namespace System.Security.Cryptography.Asn1
 {
-    internal class GeneralStringEncoding : IA5Encoding
+    internal class GeneralStringEncoding : UTF8Encoding
     {
+        public GeneralStringEncoding(): base(false, throwOnInvalidBytes: true) { }
     }
 }


### PR DESCRIPTION
### What's the problem?

ActiveDirectory supports non-Latin characters for LogonName and encodes it in UTF8.
Attempts to process such a ticket result in an error reading the PrincipalName.

- [x] Bugfix
- [ ] New Feature

### What's the solution?

Changing encoding for GeneralString to UTF8 (UTF8 is backward compatible with ASCII)

 - [ ] Includes unit tests
 - [x] Requires manual test
